### PR TITLE
Mercury REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Web-based P2P collaborative editor for live coding music and graphics
   - [TidalCycles](https://tidalcycles.org/)
   - [SuperCollider](https://supercollider.github.io/) (sclang)
   - [FoxDot](https://foxdot.org/)
+  - [Mercury](#mercury)
   - [SonicPi](https://sonic-pi.net/) (*not implemented yet*)
   - ... any interpreter with a REPL (Python, Ruby, etc.)
 * Web Plugins, for languages embedded in editor:
@@ -86,11 +87,12 @@ Examples:
 * `tidal,foxdot,hydra`: 3 slots, with tidal, foxdot and hydra respectively.
 * `sclang,sclang,sclang,hydra,hydra`: 5 slots total, the first 3 with `sclang`
   and the last 2 with `hydra`.
+* `mercury, hydra`: 2 slots total, one with Mercury and one with Hydra.
 
 Now click on *Create session*.
 
 You will now be shown a **token** and asked for a nickname. Save the token, as
-you will need it next for starting the REPL.  Enter your nickname and click on
+you will need it next for starting the REPL. Optionally copy the repl-code to easily paste in the terminal and hook up your repl. Enter your nickname and click on
 *Join*.
 
 You are ready to start writing.  Share the URL to your friends so they can join
@@ -219,6 +221,27 @@ Read
 [more](https://github.com/munshkr/flok-hydra-chrome-extension/blob/master/README.md)
 on how to install the extension.
 
+#### Mercury
+
+[Mercury](https://github.com/tmhglnd/mercury) is a minimal and human readable language for livecoding of algorithmic electronic music. Follow these steps to connect Flok to the Mercury livecoding environment:
+
+First make sure you have installed `Mercury` and `flok-repl` properly.
+1. [quick start quide](https://github.com/tmhglnd/mercury/blob/master/docs/quick-start.md) to install Mercury. 
+2. Install the `flok-repl` globally with `npm install -g flok-repl`
+
+Now follow these steps for a succesful setup.
+1. Setup Flok with target `mercury` and click **create**.
+3. Copy the `flok-repl -H xxx -s xxx -t mercury` command to run in the terminal.
+3. **join** the Flok with your *nickname*
+4. Run the copied `flok-repl` command in the terminal. Or manually set it up with argument `-t mercury`
+5. Enable *Audio* and optionally *Visuals* in Mercury to hear sound
+
+Now start typing some code! 🎵
+
+- `Ctrl/Alt + Return` to evaluate
+- `Ctrl/Alt + .` to silence
+
+Flok will send the entire code via OSC messaging to port 4880. Mercury should be listening to this port automatically. Bug reports are welcome in the issues.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -226,22 +226,22 @@ on how to install the extension.
 [Mercury](https://github.com/tmhglnd/mercury) is a minimal and human readable language for livecoding of algorithmic electronic music. Follow these steps to connect Flok to the Mercury livecoding environment:
 
 First make sure you have installed `Mercury` and `flok-repl` properly.
-1. [quick start quide](https://github.com/tmhglnd/mercury/blob/master/docs/quick-start.md) to install Mercury. 
-2. Install the `flok-repl` globally with `npm install -g flok-repl`
+1. Install Mercury via the [quick start quide](https://github.com/tmhglnd/mercury/blob/master/docs/quick-start.md). 
+2. Install the `flok-repl` globally with `npm install -g flok-repl`.
 
 Now follow these steps for a succesful setup.
-1. Setup Flok with target `mercury` and click **create**.
-3. Copy the `flok-repl -H xxx -s xxx -t mercury` command to run in the terminal.
-3. **join** the Flok with your *nickname*
-4. Run the copied `flok-repl` command in the terminal. Or manually set it up with argument `-t mercury`
-5. Enable *Audio* and optionally *Visuals* in Mercury to hear sound
+1. Setup Flok with target `mercury` and click **Create session**.
+3. Copy the `flok-repl -H xxx -s xxx -t mercury` command to run in the terminal at step 4.
+3. **Join** the Flok with your nickname.
+4. Run the copied `flok-repl` command in the terminal. Or manually set it up with argument `-t mercury`.
+5. Enable *Audio* and optionally *Visuals* in Mercury to hear sound.
 
 Now start typing some code! 🎵
 
 - `Ctrl/Alt + Return` to evaluate
 - `Ctrl/Alt + .` to silence
 
-Flok will send the entire code via OSC messaging to port 4880. Mercury should be listening to this port automatically. Bug reports are welcome in the issues.
+Flok will send the entire code via OSC messaging to port 4880. Mercury should be listening to this port automatically. Bug reports are welcome in the issues. If the issue is more Mercury than Flok related please report [here](https://github.com/tmhglnd/mercury/issues/new)
 
 ## Development
 

--- a/packages/repl/src/index.ts
+++ b/packages/repl/src/index.ts
@@ -2,6 +2,7 @@ import { BaseREPL, BaseREPLContext, CommandREPL, CommandREPLContext } from './re
 import TidalREPL from './repl/tidal';
 import SclangREPL, { RemoteSclangREPL } from './repl/sclang';
 import FoxDotREPL from './repl/foxdot';
+import MercuryREPL from './repl/mercury';
 
 const path = require("path");
 const fs = require("fs");
@@ -12,6 +13,7 @@ const replClasses = {
   sclang: SclangREPL,
   remote_sclang: RemoteSclangREPL,
   foxdot: FoxDotREPL,
+  mercury: MercuryREPL,
 };
 
 function createREPLFor(repl: string, ctx: CommandREPLContext) {

--- a/packages/repl/src/repl/mercury.ts
+++ b/packages/repl/src/repl/mercury.ts
@@ -2,6 +2,18 @@ import { BaseREPL, BaseREPLContext } from '../repl';
 // import * as os from 'os';
 import { UDPPort } from 'osc';
 
+// The Mercury REPL
+// $ flok-repl -t mercury
+// 
+// Sends the code over OSC to port 4880 on localhost
+// Start the mercury_ide.maxproj in Max8
+// Turn on the audio if you want to code sound only
+// Turn on the visuals if you want to code visuals as well
+// 
+// When executing code it should automatically receive and parse
+// Mercury only runs full pages of code (previous code is deleted)
+// So always execute full page instead of per-line
+// 
 class MercuryREPL extends BaseREPL {
   udpPort: UDPPort;
   port: number;

--- a/packages/repl/src/repl/mercury.ts
+++ b/packages/repl/src/repl/mercury.ts
@@ -1,0 +1,67 @@
+import { BaseREPL, BaseREPLContext } from '../repl';
+// import * as os from 'os';
+import { UDPPort } from 'osc';
+
+class MercuryREPL extends BaseREPL {
+  udpPort: UDPPort;
+  port: number;
+  started: boolean;
+  portReady: boolean;
+
+  constructor(ctx: BaseREPLContext) {
+    super(ctx);
+
+    this.port = 4880;
+    this.started = false;
+    this.portReady = false;
+  }
+
+  start() {
+    super.start();
+
+    this.udpPort = new UDPPort({
+      metadata: true,
+    });
+
+    // Listen for incoming OSC messages.
+    this.udpPort.on('message', function(oscMsg, timeTag, info) {
+      console.log('An OSC message just arrived!', oscMsg);
+      console.log('Remote info is: ', info);
+    });
+
+    // Open the socket.
+    this.udpPort.open();
+
+    // When the port is read, send an OSC message to, say, SuperCollider
+    const that = this;
+    this.udpPort.on('ready', function() {
+      that.portReady = true;
+    });
+
+    this.started = true;
+  }
+
+  write(body: string) {
+    if (!this.portReady) {
+      console.error('UDP Port is not ready yet.');
+      return;
+    }
+
+    const newBody = this.prepare(body);
+    const obj = {
+      address: '/mercury-code',
+      args: [
+        {
+          type: 's',
+          value: newBody,
+        },
+      ],
+    };
+    this.udpPort.send(obj, '127.0.0.1', this.port);
+
+    const lines = newBody.split('\n');
+    this.emitter.emit('data', { type: 'stdin', lines });
+  }
+}
+
+export default MercuryREPL;

--- a/packages/web/components/TextEditor.tsx
+++ b/packages/web/components/TextEditor.tsx
@@ -220,6 +220,8 @@ class TextEditor extends Component<Props, {}> {
       return "CmdPeriod.run";
     } else if (target === "foxdot") {
       return "Clock.clear()";
+    } else if (target === "mercury") {
+      return "silence";
     }
   }
 
@@ -230,17 +232,28 @@ class TextEditor extends Component<Props, {}> {
   render() {
     const { editorId, isHalfHeight, target } = this.props;
 
-    const defaultExtraKeys = {
+    let defaultExtraKeys = {
       "Shift-Enter": this.evaluateLine,
       "Ctrl-Enter": this.evaluateBlock,
       "Cmd-Enter": this.evaluateBlock,
-      // Included for Mercury that always executes full code page
-      "Alt-Enter": this.evaluateAll,
     };
+    
+    // Repalce shortkeys when using Mercury
+    // Because Mercury always replaces the entire code with the newly
+    // executed page. No per-line evaluation
+    if (target === 'mercury'){
+      defaultExtraKeys = { ...{
+        "Shift-Enter": this.evaluateAll,
+        "Ctrl-Enter": this.evaluateAll,
+        "Cmd-Enter": this.evaluateAll,
+        "Alt-Enter": this.evaluateAll,
+      } };
+    }
 
     const extraKeys = {
       "Ctrl-.": this.freeAllSound,
       "Cmd-.": this.freeAllSound,
+      "Alt-.": this.freeAllSound,
       ...defaultExtraKeys,
     };
 

--- a/packages/web/components/TextEditor.tsx
+++ b/packages/web/components/TextEditor.tsx
@@ -174,6 +174,14 @@ class TextEditor extends Component<Props, {}> {
     }
   };
 
+  // evaluate the full page of code
+  evaluateAll = () => {
+    const { editor } = this.cm;
+    const content = `${editor.getValue()}\n`;
+
+    this.evaluate(content, 0, content.length);
+  };
+
   evaluate(body: string, fromLine: number, toLine: number) {
     const { editorId, target, onEvaluateCode, sessionClient } = this.props;
 
@@ -226,6 +234,8 @@ class TextEditor extends Component<Props, {}> {
       "Shift-Enter": this.evaluateLine,
       "Ctrl-Enter": this.evaluateBlock,
       "Cmd-Enter": this.evaluateBlock,
+      // Included for Mercury that always executes full code page
+      "Alt-Enter": this.evaluateAll,
     };
 
     const extraKeys = {

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -51,7 +51,7 @@ class NewSessionForm extends Component<
         <TextInput
           name="user"
           value={targets}
-          placeholder={`Enter targets separated by commas (e.g. tidal,foxdot,hydra)`}
+          placeholder={`Enter targets separated by commas (e.g. tidal,foxdot,etc.)`}
           autoFocus
           onChange={this.handleChangeTargets}
           disabled={submitting}
@@ -89,11 +89,37 @@ const Title = () => (
   </header>
 );
 
+// The supported targets that can be entered in the form
+const SupportedTargets = () => (
+  <body>
+    <h3>currently supported targets:</h3>
+    <p>
+      <li>tidal</li>
+      <li>foxdot</li>
+      <li>hydra</li>
+      <li>sclang</li>
+      <li>remote_sclang</li>
+      <li>mercury</li>
+    </p>
+    <style jsx>{`
+      h3 {
+        font-size: 1 em;
+        color: #ffffff75
+      }
+      p {
+        font-size: 0.8 em;
+        color: #ffffff75
+      }
+    `}</style>
+  </body>
+);
+
 const IndexPage = () => (
   <Layout>
     <Container>
       <Title />
       <NewSessionForm />
+      <SupportedTargets />
       {hasWebgl() && <FlockScene />}
     </Container>
   </Layout>

--- a/packages/web/pages/s/[session].tsx
+++ b/packages/web/pages/s/[session].tsx
@@ -147,13 +147,15 @@ const EmptySession = ({
   hasWebGl,
   hasHydraSlot,
   onSubmit,
+  layout,
 }) => {
   const [username, setUsername] = useState(lastUsername);
   const [copied, setCopied] = useState(false);
 
-  const replExample = `flok-repl -H ${websocketsUrl} -s ${session} -t tidal${
-    username ? ` -N ${username}` : ""
-  }`;
+  // pick the first target as example for the repl
+  const targetExample = layout[0];
+  // apply websocket, session, targetexample and username to string
+  const replExample = `flok-repl -H ${websocketsUrl} -s ${session} -t ${targetExample}${ username ? ` -N ${username}` : "" }`;
 
   const copyToClipboard = () => {
     setCopied(true);
@@ -181,7 +183,7 @@ const EmptySession = ({
             onSubmit={onSubmit}
           />
           <p>
-            To connect a REPL, for example, <code>tidal</code>, run on a
+            To connect a REPL, for example <code>{targetExample}</code>, run on a
             terminal:
           </p>
           <div className="example">
@@ -417,6 +419,7 @@ class SessionPage extends Component<Props, State> {
             onSubmit={this.handleJoinSubmit}
             hasHydraSlot={hasHydraSlot}
             hasWebGl={hasWebGl}
+            layout={layoutList}
           />
         )}
         {hasWebgl && (


### PR DESCRIPTION
Few things I added:
- `mercury` repl option for the `flok-repl` command line, based on the RemoteSCLangRepl class
- Homepage of Flok now includes a list of supported targets
- The repl-example on second page now automatically uses first target of the list for easily copy-pasting to terminal
- Included an `evaluateAll()` method because Mercury does not work with block/per-line evaluating
- Included `Alt+return` and `Alt+.` shortkeys for evaluate/silence
- Updated the README for Mercury