### PR TITLE
Follow remote cursors when moving (i.e. jump to line)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* web: Follow remote cursors when moving (jump to line), but only if editor is
+  blurred.
+
 ### Changed
 
 * web: Skip 'hydra' as a flok-repl example when joining a session
+
 
 ## [0.4.3] - 2020-12-04
 

--- a/packages/web/components/TextEditor.tsx
+++ b/packages/web/components/TextEditor.tsx
@@ -182,7 +182,7 @@ class TextEditor extends Component<Props, {}> {
 
     this.evaluate(content, 0, content.length, locally);
   };
-  
+
   evaluate(body: string, fromLine: number = -1, toLine: number = -1, locally: boolean = false) {
     const { editorId, target, onEvaluateCode, sessionClient } = this.props;
 
@@ -232,20 +232,22 @@ class TextEditor extends Component<Props, {}> {
       "Ctrl-Alt-Enter": () => this.evaluateBlock(true),
       "Cmd-Alt-Enter": () => this.evaluateBlock(true),
     };
-    
-    // Repalce shortkeys when using Mercury
+
+    // Replace shortkeys when using Mercury
     // Because Mercury always replaces the entire code with the newly
     // executed page. No per-line evaluation
-    if (target === 'mercury'){
-      defaultExtraKeys = { ...{
-        "Shift-Enter": () => this.evaluateAll(false),
-        "Ctrl-Enter": () => this.evaluateAll(false),
-        "Cmd-Enter": () => this.evaluateAll(false),
-        "Alt-Enter": () => this.evaluateAll(false),
-        "Shift-Alt-Enter": () => this.evaluateAll(true),
-        "Ctrl-Alt-Enter": () => this.evaluateAll(true),
-        "Cmd-Alt-Enter": () => this.evaluateAll(true),
-      } };
+    if (target === 'mercury') {
+      defaultExtraKeys = {
+        ...{
+          "Shift-Enter": () => this.evaluateAll(false),
+          "Ctrl-Enter": () => this.evaluateAll(false),
+          "Cmd-Enter": () => this.evaluateAll(false),
+          "Alt-Enter": () => this.evaluateAll(false),
+          "Shift-Alt-Enter": () => this.evaluateAll(true),
+          "Ctrl-Alt-Enter": () => this.evaluateAll(true),
+          "Cmd-Alt-Enter": () => this.evaluateAll(true),
+        }
+      };
     }
 
     const extraKeys = {


### PR DESCRIPTION
Only if editor is blurred (unfocused).
    
Fixes #33
