### PR TITLE
FoxDot: Load custom modifications on startup

### DIFF
--- a/packages/repl/src/repl/foxdot.ts
+++ b/packages/repl/src/repl/foxdot.ts
@@ -5,7 +5,7 @@ class FoxDotREPL extends CommandREPL {
     super(ctx);
 
     this.command = this.commandPath();
-    this.args = ['-i', '-c', '"from FoxDot import *"'];
+    this.args = ['-i', '-c', '"from FoxDot import *\nload_startup_file()"'];
   }
 
   // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
FoxDot has a file called startup.py that you can modify to incorporate new features. FoxDot GUI loads it in the startup but Flok isn't. It's just adding a `load_startup_file()` line in the startup.