### PR TITLE
Fix package bundle by removing `next-transpile-modules` and using externals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * web: Replace yjsdemo WebSocket Yjs server for an embedded WS server
+* web: Use a random english name + first 8 chars of uuid as default session name
 * web: Upgrade p5 to version 1.4.1
 * web: Upgrade hydra-synth to version 1.3.16
 * web: Upgrade Next to version 12
-* web: Use a random english name + first 8 chars of uuid as default session name
+* web: Fix package bundle
 
 ## [0.4.6] - 2021-10-31
 

--- a/packages/web/.npmignore
+++ b/packages/web/.npmignore
@@ -2,3 +2,4 @@
 /pages/
 /styles/
 /test/
+/.next/cache/*

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -1,10 +1,5 @@
 /* eslint-disable no-param-reassign */
 // next.config.js
-const withTM = require("next-transpile-modules")([
-  "lib0",
-  "y-protocols",
-  "y-indexeddb",
-]);
 const process = require("process");
 const path = require("path");
 const fs = require("fs");
@@ -13,7 +8,7 @@ const packageConfig = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, "package.json"))
 );
 
-module.exports = withTM({
+module.exports = {
   swcMinify: true,
 
   publicRuntimeConfig: {
@@ -31,6 +26,14 @@ module.exports = withTM({
       fs: false,
     };
 
+    // Skip the following modules from transpiling
+    config.externals = [
+      ...config.externals,
+      'lib0',
+      'y-protocols',
+      'y-indexeddb'
+    ];
+
     config.module.rules.push({
       test: /\.(eot|woff|woff2|ttf|svg|png|jpg|gif)$/,
       use: {
@@ -44,4 +47,4 @@ module.exports = withTM({
 
     return config;
   },
-});
+};

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -25,7 +25,7 @@
     "flok-core": "^0.4.7",
     "lib0": "^0.2.26",
     "next": "12",
-    "next-transpile-modules": "^8.0.0",
+    "next-transpile-modules": "^9.0.0",
     "normalize.css": "^8.0.1",
     "p5": "^1.4.1",
     "react": "^18.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -25,7 +25,6 @@
     "flok-core": "^0.4.7",
     "lib0": "^0.2.26",
     "next": "12",
-    "next-transpile-modules": "^9.0.0",
     "normalize.css": "^8.0.1",
     "p5": "^1.4.1",
     "react": "^18.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -33,7 +33,8 @@
     "simple-peer": "^9.6.2",
     "unique-names-generator": "^4.7.1",
     "ws": "^7.0.1",
-    "y-indexeddb": "^9.0.6"
+    "y-indexeddb": "^9.0.6",
+    "y-protocols": "^0.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",
@@ -53,7 +54,6 @@
     "reconnecting-websocket": "^4.1.10",
     "typescript": "^4.3.5",
     "uuid": "^8.3.2",
-    "y-protocols": "^0.2.0",
     "yjs": "^13.0.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2807,14 +2807,6 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@^5.7.0:
-  version "5.8.2"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz#15ddc779345cbb73e97c611cd00c01c1e7bf4d8b"
-  integrity sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==
-  dependencies:
-    graceful-fs "^4.2.4"
-    tapable "^2.2.0"
-
 enquirer@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
@@ -3779,11 +3771,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
-
-graceful-fs@^4.2.4:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
-  integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
 handlebars@^4.4.0:
   version "4.7.7"
@@ -5220,14 +5207,6 @@ neo-async@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
-
-next-transpile-modules@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/next-transpile-modules/-/next-transpile-modules-9.0.0.tgz#133b1742af082e61cc76b02a0f12ffd40ce2bf90"
-  integrity sha512-VCNFOazIAnXn1hvgYYSTYMnoWgKgwlYh4lm1pKbSfiB3kj5ZYLcKVhfh3jkPOg1cnd9DP+pte9yCUocdPEUBTQ==
-  dependencies:
-    enhanced-resolve "^5.7.0"
-    escalade "^3.1.1"
 
 next@12:
   version "12.1.6"
@@ -7150,11 +7129,6 @@ table@^6.0.9:
     slice-ansi "^4.0.0"
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
-
-tapable@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.0.tgz#5c373d281d9c672848213d0e037d1c4165ab426b"
-  integrity sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==
 
 tar-fs@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5221,10 +5221,10 @@ neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-next-transpile-modules@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/next-transpile-modules/-/next-transpile-modules-8.0.0.tgz#56375cdc25ae5d23a834195f277fc2737b26cb97"
-  integrity sha512-Q2f2yB0zMJ8KJbIYAeZoIxG6cSfVk813zr6B5HzsLMBVcJ3FaF8lKr7WG66n0KlHCwjLSmf/6EkgI6QQVWHrDw==
+next-transpile-modules@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/next-transpile-modules/-/next-transpile-modules-9.0.0.tgz#133b1742af082e61cc76b02a0f12ffd40ce2bf90"
+  integrity sha512-VCNFOazIAnXn1hvgYYSTYMnoWgKgwlYh4lm1pKbSfiB3kj5ZYLcKVhfh3jkPOg1cnd9DP+pte9yCUocdPEUBTQ==
   dependencies:
     enhanced-resolve "^5.7.0"
     escalade "^3.1.1"


### PR DESCRIPTION
This moves `lib0`, `y-protocols` and `y-indexeddb` as runtime dependencies, marks them as externals to Webpack to avoid transpiling and bundling them into `flok-web`.