### PR TITLE
Add free-all-sound for Sardine. Default to empty string for bodyless messages.

### DIFF
--- a/packages/repl/src/repl.ts
+++ b/packages/repl/src/repl.ts
@@ -58,7 +58,7 @@ abstract class BaseREPL {
     // Subscribe to pub sub
     const { target, session } = this;
     this.pubSub.subscribe(`session:${session}:target:${target}:in`, (message: Message) => {
-      const { body } = message;
+      const { body = '' } = message;
       this.write(body);
     });
   }

--- a/packages/web/components/TextEditor.tsx
+++ b/packages/web/components/TextEditor.tsx
@@ -301,6 +301,8 @@ class TextEditor extends Component<Props, {}> {
       return "hush()";
     } else if (target == "strudel") {
       return '"~".out()';
+    } else if (target == "sardine") {
+      return "panic()";
     }
   }
 


### PR DESCRIPTION
Added a condition to insert Sardine's free-all-sound code.

If `freeAllSoundCode` isn't implemented for a given language, ctrl-. crashes the repl.

```
/.../flok/packages/repl/lib/repl.js:31
        return body.trim();
                    ^

TypeError: Cannot read property 'trim' of undefined
    at SardineREPL.prepare (/.../flok/packages/repl/lib/repl.js:31:21)
    at SardineREPL.write (/.../flok/packages/repl/lib/repl.js:70:30)
    at /.../flok/packages/repl/lib/repl.js:26:18
    at BaseEventEmitter.__emitToSubscription (/.../flok/node_modules/fbemitter/lib/BaseEventEmitter.js:185:27)
    at BaseEventEmitter.emit (/.../flok/node_modules/fbemitter/lib/BaseEventEmitter.js:166:37)
    at WebSocket.ws.onmessage (/.../flok/packages/core/lib/PubSubClient.js:242:34)
    at callListener (/.../flok/node_modules/ws/lib/event-target.js:290:14)
    at WebSocket.onMessage (/.../flok/node_modules/ws/lib/event-target.js:209:9)
    at WebSocket.emit (events.js:400:28)
    at Receiver.receiverOnMessage (/.../flok/node_modules/ws/lib/websocket.js:1180:20)

```
And for Sardine this entails leaving a dangling Python process.
So, I propose destructuring `body` to an empty string.