### PR TITLE
Changing Sardine interpreter name

### DIFF
--- a/packages/repl/src/repl/sardine.ts
+++ b/packages/repl/src/repl/sardine.ts
@@ -10,7 +10,7 @@ class SardineREPL extends CommandREPL {
 
   commandPath(): string {
     const { python } = this.extraOptions;
-    return python || 'fishery';
+    return python || 'sardine';
   }
 }
 


### PR DESCRIPTION
Due to an internal package restructuration, the Sardine interpreter (previously `fishery`) is now named `sardine`. This commit is changing the command invoked by Flok to spawn the interpreter.