### PR TITLE
allow running multiple strudel instances in parallel

### DIFF
--- a/packages/web/src/hooks/use-strudel.tsx
+++ b/packages/web/src/hooks/use-strudel.tsx
@@ -12,7 +12,7 @@ export function useStrudel(
     session,
     async () => {
       console.log("Create StrudelWrapper");
-      const strudel = new StrudelWrapper({ onError, onWarning, session });
+      const strudel = new StrudelWrapper({ onError, onWarning });
 
       console.log("Import Strudel modules");
       await strudel.importModules();

--- a/packages/web/src/hooks/use-strudel.tsx
+++ b/packages/web/src/hooks/use-strudel.tsx
@@ -12,7 +12,7 @@ export function useStrudel(
     session,
     async () => {
       console.log("Create StrudelWrapper");
-      const strudel = new StrudelWrapper({ onError, onWarning });
+      const strudel = new StrudelWrapper({ onError, onWarning, session });
 
       console.log("Import Strudel modules");
       await strudel.importModules();
@@ -20,7 +20,7 @@ export function useStrudel(
       return strudel;
     },
     {
-      onEval: (instance, { body }) => instance.tryEval(body),
+      onEval: (instance, msg) => instance.tryEval(msg),
       onError,
     }
   );

--- a/packages/web/src/lib/strudel-wrapper.ts
+++ b/packages/web/src/lib/strudel-wrapper.ts
@@ -1,4 +1,4 @@
-import { EvalMessage, Session } from "@flok-editor/session";
+import { EvalMessage } from "@flok-editor/session";
 import { repl, controls, evalScope, stack } from "@strudel.cycles/core";
 import { evaluate } from "@strudel.cycles/transpiler";
 import { transpiler } from "@strudel.cycles/transpiler";
@@ -17,19 +17,15 @@ export class StrudelWrapper {
   protected _onError: ErrorHandler;
   protected _onWarning: ErrorHandler;
   protected _repl: any;
-  protected _session: Session | null;
   protected _docPatterns: any;
 
   constructor({
     onError,
     onWarning,
-    session,
   }: {
     onError?: ErrorHandler;
     onWarning?: ErrorHandler;
-    session: Session | null;
   }) {
-    this._session = session;
     this._docPatterns = {};
     this._onError = onError || (() => {});
     this._onWarning = onWarning || (() => {});

--- a/packages/web/src/lib/strudel-wrapper.ts
+++ b/packages/web/src/lib/strudel-wrapper.ts
@@ -1,4 +1,6 @@
-import { repl, controls, evalScope } from "@strudel.cycles/core";
+import { EvalMessage, Session } from "@flok-editor/session";
+import { repl, controls, evalScope, stack } from "@strudel.cycles/core";
+import { evaluate } from "@strudel.cycles/transpiler";
 import { transpiler } from "@strudel.cycles/transpiler";
 import {
   getAudioContext,
@@ -15,14 +17,20 @@ export class StrudelWrapper {
   protected _onError: ErrorHandler;
   protected _onWarning: ErrorHandler;
   protected _repl: any;
+  protected _session: Session | null;
+  protected _docPatterns: any;
 
   constructor({
     onError,
     onWarning,
+    session,
   }: {
     onError?: ErrorHandler;
     onWarning?: ErrorHandler;
+    session: Session | null;
   }) {
+    this._session = session;
+    this._docPatterns = {};
     this._onError = onError || (() => {});
     this._onWarning = onWarning || (() => {});
   }
@@ -43,8 +51,8 @@ export class StrudelWrapper {
     );
     try {
       await samples(
-        "https://strudel.tidalcycles.org/EmuSP12.json",
-        "https://strudel.tidalcycles.org/EmuSP12/"
+        "https://strudel.cc/EmuSP12.json",
+        "https://strudel.cc/EmuSP12/"
       );
     } catch (err) {
       this._onWarning(`Failed to load default samples EmuSP12: ${err}`);
@@ -63,14 +71,16 @@ export class StrudelWrapper {
     });
 
     this.initialized = true;
-    console.log("Strudel initialized");
   }
 
-  async tryEval(code: string) {
+  async tryEval(msg: EvalMessage) {
     if (!this.initialized) await this.initialize();
-
     try {
-      await this._repl.evaluate(code);
+      const { body: code, docId } = msg;
+      const { pattern } = await evaluate(code);
+      this._docPatterns[docId] = pattern;
+      const allPatterns = stack(...Object.values(this._docPatterns));
+      await this._repl.scheduler.setPattern(allPatterns, true);
       this._onError("");
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
changes the strudel integration to:

- keeps an object that maps from docId to pattern
- each evaluation will just update the pattern with the corresponding docId
- after each evaluation, all current patterns will be stacked and passed to the repl instance

~~I have yet to test if that works across multiple machines~~ tested over local wifi and it works!