### PR TITLE
fix(repl): Do not reject unauthorized Flok servers (fixes #202)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "1.0.0-alpha.8"
+  "version": "1.0.0-alpha.9"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16099,14 +16099,14 @@
       }
     },
     "packages/example-vanilla-js": {
-      "version": "1.0.0-alpha.4",
+      "version": "1.0.0-alpha.9",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.1.4",
         "@codemirror/state": "^6.2.0",
         "@codemirror/theme-one-dark": "^6.1.1",
         "@codemirror/view": "^6.9.3",
         "@flok-editor/cm-eval": "^1.0.0-alpha.4",
-        "@flok-editor/session": "^1.0.0-alpha.4",
+        "@flok-editor/session": "^1.0.0-alpha.9",
         "codemirror": "^6.0.1",
         "y-codemirror.next": "^0.3.2",
         "y-indexeddb": "^9.0.9",
@@ -16224,7 +16224,7 @@
     },
     "packages/pubsub": {
       "name": "@flok-editor/pubsub",
-      "version": "1.0.0-alpha.4",
+      "version": "1.0.0-alpha.9",
       "license": "GPL-3.0+",
       "dependencies": {
         "bufferutil": "^4.0.7",
@@ -16253,10 +16253,10 @@
     },
     "packages/repl": {
       "name": "flok-repl",
-      "version": "1.0.0-alpha.6",
+      "version": "1.0.0-alpha.9",
       "license": "GPL-3.0+",
       "dependencies": {
-        "@flok-editor/pubsub": "^1.0.0-alpha.4",
+        "@flok-editor/pubsub": "^1.0.0-alpha.9",
         "command-exists": "^1.2.9",
         "commander": "^10.0.0",
         "debug": "^4.3.4",
@@ -16284,10 +16284,10 @@
     },
     "packages/server": {
       "name": "flok-server",
-      "version": "1.0.0-alpha.8",
+      "version": "1.0.0-alpha.9",
       "license": "GPL-3.0+",
       "dependencies": {
-        "@flok-editor/server-middleware": "^1.0.0-alpha.4",
+        "@flok-editor/server-middleware": "^1.0.0-alpha.9",
         "commander": "^10.0.1",
         "debug": "^4.3.4",
         "lib0": "^0.2.63",
@@ -16300,10 +16300,10 @@
     },
     "packages/server-middleware": {
       "name": "@flok-editor/server-middleware",
-      "version": "1.0.0-alpha.4",
+      "version": "1.0.0-alpha.9",
       "license": "GPL-3.0+",
       "dependencies": {
-        "@flok-editor/pubsub": "^1.0.0-alpha.4",
+        "@flok-editor/pubsub": "^1.0.0-alpha.9",
         "debug": "^4.3.4"
       },
       "devDependencies": {
@@ -16319,10 +16319,10 @@
     },
     "packages/session": {
       "name": "@flok-editor/session",
-      "version": "1.0.0-alpha.4",
+      "version": "1.0.0-alpha.9",
       "license": "GPL-3.0+",
       "dependencies": {
-        "@flok-editor/pubsub": "^1.0.0-alpha.4",
+        "@flok-editor/pubsub": "^1.0.0-alpha.9",
         "debug": "^4.3.4",
         "events": "^3.3.0"
       },
@@ -16340,7 +16340,7 @@
     },
     "packages/web": {
       "name": "flok-web",
-      "version": "1.0.0-alpha.7",
+      "version": "1.0.0-alpha.9",
       "license": "GPL-3.0+",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.1.4",
@@ -16350,8 +16350,8 @@
         "@codemirror/view": "^6.9.3",
         "@flok-editor/cm-eval": "^1.0.0-alpha.4",
         "@flok-editor/lang-tidal": "^1.0.0-alpha.4",
-        "@flok-editor/server-middleware": "^1.0.0-alpha.4",
-        "@flok-editor/session": "^1.0.0-alpha.4",
+        "@flok-editor/server-middleware": "^1.0.0-alpha.9",
+        "@flok-editor/session": "^1.0.0-alpha.9",
         "@radix-ui/react-dialog": "^1.0.3",
         "@radix-ui/react-dropdown-menu": "^2.0.4",
         "@radix-ui/react-label": "^2.0.1",

--- a/packages/example-vanilla-js/package.json
+++ b/packages/example-vanilla-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-vanilla-js",
   "private": true,
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.9",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -17,7 +17,7 @@
     "@codemirror/theme-one-dark": "^6.1.1",
     "@codemirror/view": "^6.9.3",
     "@flok-editor/cm-eval": "^1.0.0-alpha.4",
-    "@flok-editor/session": "^1.0.0-alpha.4",
+    "@flok-editor/session": "^1.0.0-alpha.9",
     "codemirror": "^6.0.1",
     "y-codemirror.next": "^0.3.2",
     "y-indexeddb": "^9.0.9",

--- a/packages/pubsub/lib/client.ts
+++ b/packages/pubsub/lib/client.ts
@@ -114,7 +114,7 @@ export class PubSubClient {
 
   protected _connect() {
     debug("create WebSocket on", this.url);
-    this._ws = new WebSocket(this.url);
+    this._ws = new WebSocket(this.url, { rejectUnauthorized: false });
 
     this._ws.onopen = () => {
       if (!this._ws) return;

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flok-editor/pubsub",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.9",
   "description": "Pub/Sub client-server, used for remote code execution and message passing on Flok",
   "author": "Damián Silvani <munshkr@gmail.com>",
   "license": "GPL-3.0+",

--- a/packages/repl/package.json
+++ b/packages/repl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flok-repl",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.9",
   "description": "REPL client for Flok",
   "author": "Damián Silvani <munshkr@gmail.com>",
   "license": "GPL-3.0+",
@@ -24,7 +24,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@flok-editor/pubsub": "^1.0.0-alpha.4",
+    "@flok-editor/pubsub": "^1.0.0-alpha.9",
     "command-exists": "^1.2.9",
     "commander": "^10.0.0",
     "debug": "^4.3.4",

--- a/packages/server-middleware/package.json
+++ b/packages/server-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flok-editor/server-middleware",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.9",
   "description": "Server middleware for Flok, handles WebSocket connections and WebRTC signaling",
   "author": "Damián Silvani <munshkr@gmail.com>",
   "license": "GPL-3.0+",
@@ -23,7 +23,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@flok-editor/pubsub": "^1.0.0-alpha.4",
+    "@flok-editor/pubsub": "^1.0.0-alpha.9",
     "debug": "^4.3.4"
   },
   "devDependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flok-server",
-  "version": "1.0.0-alpha.8",
+  "version": "1.0.0-alpha.9",
   "description": "Flok server, handles WebSocket connections and WebRTC signaling",
   "author": "Damián Silvani <munshkr@gmail.com>",
   "license": "GPL-3.0+",
@@ -13,7 +13,7 @@
     "start": "node bin/flok-server.js"
   },
   "dependencies": {
-    "@flok-editor/server-middleware": "^1.0.0-alpha.4",
+    "@flok-editor/server-middleware": "^1.0.0-alpha.9",
     "commander": "^10.0.1",
     "debug": "^4.3.4",
     "lib0": "^0.2.63",

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flok-editor/session",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.9",
   "description": "Flok Session package",
   "author": "Damián Silvani <munshkr@gmail.com>",
   "license": "GPL-3.0+",
@@ -22,7 +22,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@flok-editor/pubsub": "^1.0.0-alpha.4",
+    "@flok-editor/pubsub": "^1.0.0-alpha.9",
     "debug": "^4.3.4",
     "events": "^3.3.0"
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flok-web",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.9",
   "description": "Web server for Flok",
   "author": "Damián Silvani <munshkr@gmail.com>",
   "license": "GPL-3.0+",
@@ -25,8 +25,8 @@
     "@codemirror/view": "^6.9.3",
     "@flok-editor/cm-eval": "^1.0.0-alpha.4",
     "@flok-editor/lang-tidal": "^1.0.0-alpha.4",
-    "@flok-editor/server-middleware": "^1.0.0-alpha.4",
-    "@flok-editor/session": "^1.0.0-alpha.4",
+    "@flok-editor/server-middleware": "^1.0.0-alpha.9",
+    "@flok-editor/session": "^1.0.0-alpha.9",
     "@radix-ui/react-dialog": "^1.0.3",
     "@radix-ui/react-dropdown-menu": "^2.0.4",
     "@radix-ui/react-label": "^2.0.1",


### PR DESCRIPTION
Useful when trying to connect to Flok servers running with self-signed certificates.