### PR TITLE
Updated mercury engine that fixes sample loading bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9826,19 +9826,19 @@
       }
     },
     "node_modules/mercury-engine": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/mercury-engine/-/mercury-engine-1.0.9.tgz",
-      "integrity": "sha512-vg9e2OsyNLZZWEo5/92fmvSTFe1st2fYXTcEzkHmDmgqHoFY7FDxgerWXinKqVuT2spEMvX+2G5qaT+xERQdbw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mercury-engine/-/mercury-engine-1.1.0.tgz",
+      "integrity": "sha512-W+joRdU9rrXGWJqrGrvws/2ZSOjCwXSZLjBIDB3Fg+K+izdxsqKh20+gTQm6zJdm+POOz/DE5R38Dp3kGJiAog==",
       "dependencies": {
-        "mercury-lang": "^1.9.3",
+        "mercury-lang": "^1.9.x",
         "tone": "^14.7.77",
         "webmidi": "^3.1.6"
       }
     },
     "node_modules/mercury-lang": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/mercury-lang/-/mercury-lang-1.9.4.tgz",
-      "integrity": "sha512-9zhBHl2kbsFCUsoACqkXnz4UJDnBiMynY+Ui4riu1Tkz9JDEihXWBVPXtiiNcj8jttoz0GM8oArUDTfiWkMg/A==",
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/mercury-lang/-/mercury-lang-1.9.6.tgz",
+      "integrity": "sha512-FBmTYy3vourq2VcmhgM/1tJRVjzZ/GYLEUe3QQ9dqsNlK54RiTTYcDkqGRLry0GnF7bfWJi9GUWvqCcQvY4VZg==",
       "dependencies": {
         "moo": "^0.5.1",
         "nearley": "^2.20.1",
@@ -16371,7 +16371,7 @@
         "express": "^4.18.2",
         "hydra-synth": "github:munshkr/hydra-synth#avoid-eval",
         "lucide-react": "^0.128.0",
-        "mercury-engine": "^1.0.9",
+        "mercury-engine": "^1.1.0",
         "p5": "^1.6.0",
         "picocolors": "^1.0.0",
         "react": "^18.2.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -54,7 +54,7 @@
     "express": "^4.18.2",
     "hydra-synth": "github:munshkr/hydra-synth#avoid-eval",
     "lucide-react": "^0.128.0",
-    "mercury-engine": "^1.0.9",
+    "mercury-engine": "^1.1.0",
     "p5": "^1.6.0",
     "picocolors": "^1.0.0",
     "react": "^18.2.0",

--- a/packages/web/src/lib/mercury-wrapper.ts
+++ b/packages/web/src/lib/mercury-wrapper.ts
@@ -30,7 +30,7 @@ export class MercuryWrapper {
     // set initialized to true only when samples are loaded
     this._repl = new Mercury({
       onload: () => { 
-        this._onWarning(`Mercury ready!`);
+        this._onWarning(`Ready!`);
         // console.log('Mercury loaded');
         this.initialized = true;
         // retry the evaluation
@@ -53,7 +53,12 @@ export class MercuryWrapper {
         let parse = this._repl.code(code);
         this._onError('');
   
-        if (parse.errors){
+        let prints = parse.parseTree.print;
+        if (prints.length > 0){
+          // print prints from the code if there are any
+          this._onWarning(`${prints}`);
+        }
+        if (parse.errors.length > 0){
           console.log(parse.errors);
           // print the first error that needs fixing
           this._onError(`${parse.errors}`);


### PR DESCRIPTION
There was a bug in the engine that didn't allow external samples (from eg freesound/github) to be loaded with `set samples <url>`. This should now be fixed.

Also some other updates have been included such as:

- `once()` to play a sample/synth only once
- `fx(chorus)`/`fx(double)` effects
- ramptimes for `volume` `hipass` `lopass` `tempo` can be set in musical division

