### PR TITLE
Output RMS meter value from Mercury to use as variable in Hydra code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9826,9 +9826,9 @@
       }
     },
     "node_modules/mercury-engine": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mercury-engine/-/mercury-engine-1.1.0.tgz",
-      "integrity": "sha512-W+joRdU9rrXGWJqrGrvws/2ZSOjCwXSZLjBIDB3Fg+K+izdxsqKh20+gTQm6zJdm+POOz/DE5R38Dp3kGJiAog==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mercury-engine/-/mercury-engine-1.2.0.tgz",
+      "integrity": "sha512-iWQhEFsRuWWrDIxjTmcm12782biou44A1JnEhZCrX0xO6AvjZiYsFPjHUgt4TXfet2eC4SYgqM2cnSn1/7RP1Q==",
       "dependencies": {
         "mercury-lang": "^1.9.x",
         "tone": "^14.7.77",
@@ -16379,7 +16379,7 @@
         "express": "^4.18.2",
         "hydra-synth": "github:munshkr/hydra-synth#avoid-eval",
         "lucide-react": "^0.128.0",
-        "mercury-engine": "^1.1.0",
+        "mercury-engine": "^1.2.0",
         "p5": "^1.6.0",
         "picocolors": "^1.0.0",
         "react": "^18.2.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -54,7 +54,7 @@
     "express": "^4.18.2",
     "hydra-synth": "github:munshkr/hydra-synth#avoid-eval",
     "lucide-react": "^0.128.0",
-    "mercury-engine": "^1.1.0",
+    "mercury-engine": "^1.2.0",
     "p5": "^1.6.0",
     "picocolors": "^1.0.0",
     "react": "^18.2.0",

--- a/packages/web/src/lib/mercury-wrapper.ts
+++ b/packages/web/src/lib/mercury-wrapper.ts
@@ -1,6 +1,13 @@
 
 import { Mercury } from "mercury-engine";
 
+// global variable m for the main output sound from Mercury
+declare global {
+  interface Window {
+    m : any;
+  }
+}
+
 export type ErrorHandler = (error: string) => void;
 
 export class MercuryWrapper {
@@ -10,6 +17,7 @@ export class MercuryWrapper {
   protected _onWarning: ErrorHandler;
   protected _repl: any;
   protected _code: any;
+  protected _meter: any;
   // protected _docPatterns: any;
 
   constructor({
@@ -35,6 +43,11 @@ export class MercuryWrapper {
         this.initialized = true;
         // retry the evaluation
         this.tryEval(this._code);
+
+        // initialize the meter
+        this._repl.addMeter();
+        // update the value every 16ms for 60fps
+        this._meter = setInterval(() => window.m = this._repl.getMeter(), 16);
       },
       onmidi: () => { console.log('MIDI devices ready') }
     });


### PR DESCRIPTION
Hey! This is a little update I've been working on that allows to use the audio output from Mercury as a variable in Hydra. I was not able to connect with Hydra via the already existing `a.fft` method Hydra has. Instead I've made use of the `Tone.Meter()` to do an rms measurement of the sound myself in the Mercury engine and combined with a `setInterval` the value can be polled every 16ms for a smooth frame update. I've used the letter `m` to store the value in, but let me know if this is not desirable for whatever reason.

Here's some little example snippets to try it with:

Hydra:
```js
osc(10, 0.2, () => m * 10).hue(() => m * 2).out()
```
Mercury:
```java
set tempo 100
new sample [[kick_min hat_808 snare_step]] time(1/16) play(euclid(16 9))
```