### PR TITLE
fix(repl): Default `--types` arg should be an array, not a string

### DIFF
--- a/packages/repl/bin/flok-repl.js
+++ b/packages/repl/bin/flok-repl.js
@@ -28,7 +28,7 @@ const program = new Command();
 
 program.version(packageInfo.version);
 program
-  .option("-t, --types <types...>", "Type/s of REPL", "command")
+  .option("-t, --types <types...>", "Type/s of REPL", ["command"])
   .option("-H, --hub <url>", "Server (or \"hub\") address", "ws://localhost:3000")
   .option("-s, --session-name <name>", "Session name", "default")
   .option("-n, --target-name <name>", "Use the specified target name")


### PR DESCRIPTION
This fixes the following bug when trying to run `flok-repl` without `-T/--types` option:

```sh
$ bin/flok-repl.js
Unknown types: c, o, m, a, n, d. Must be one of: [
  'command',
  'tidal',
  'sclang',
  'remote_sclang',
  'foxdot',
  'mercury',
  'sardine'
]```