### PR TITLE
fix: use repl.evaluate to make setcps work

### DIFF
--- a/packages/web/src/lib/strudel-wrapper.ts
+++ b/packages/web/src/lib/strudel-wrapper.ts
@@ -8,7 +8,7 @@ import {
   Pattern,
   valueToMidi,
 } from "@strudel/core";
-import { evaluate, transpiler } from "@strudel/transpiler";
+import { transpiler } from "@strudel/transpiler";
 import {
   getAudioContext,
   initAudioOnFirstClick,

--- a/packages/web/src/lib/strudel-wrapper.ts
+++ b/packages/web/src/lib/strudel-wrapper.ts
@@ -83,7 +83,7 @@ export class StrudelWrapper {
     if (!this.initialized) await this.initialize();
     try {
       const { body: code, docId } = msg;
-      const { pattern } = await evaluate(code);
+      const pattern = await this._repl.evaluate(code);
       this._docPatterns[docId] = pattern;
       const allPatterns = stack(...Object.values(this._docPatterns));
       await this._repl.scheduler.setPattern(allPatterns, true);


### PR DESCRIPTION
the strudel wrapper is now using the evaluate method from the repl instance, which adds setcps to the scope + has better error handling.