### PR TITLE
fix: silence when pattern gets undefined

### DIFF
--- a/packages/web/src/lib/strudel-wrapper.ts
+++ b/packages/web/src/lib/strudel-wrapper.ts
@@ -84,10 +84,12 @@ export class StrudelWrapper {
     try {
       const { body: code, docId } = msg;
       const pattern = await this._repl.evaluate(code);
-      this._docPatterns[docId] = pattern;
-      const allPatterns = stack(...Object.values(this._docPatterns));
-      await this._repl.scheduler.setPattern(allPatterns, true);
-      this._onError("");
+      if (pattern) {
+        this._docPatterns[docId] = pattern;
+        const allPatterns = stack(...Object.values(this._docPatterns));
+        await this._repl.scheduler.setPattern(allPatterns, true);
+        this._onError("");
+      }
     } catch (err) {
       console.error(err);
       this._onError(`${err}`);


### PR DESCRIPTION
after https://github.com/munshkr/flok/pull/253 , any syntax error would lead to silence which is a nono. this is now fixed. (errors are still catched in `onEvalError`)