### PR TITLE
add strudel/codemirror to prepare highlighting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -567,13 +567,13 @@
       }
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.4.2.tgz",
-      "integrity": "sha512-8WE2xp+D0MpWEv5lZ6zPW1/tf4AGb358T5GWYiKEuCP8MvFfT3tH2mIF9Y2yr2e3KbHuSvsVhosiEyqCpiJhZQ==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.12.0.tgz",
+      "integrity": "sha512-r4IjdYFthwbCQyvqnSlx0WBHRHi8nBvU+WjJxFUij81qsBfhNudf/XKKmmC2j3m0LaOYUQTf3qiEK1J8lO1sdg==",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.6.0",
+        "@codemirror/view": "^6.17.0",
         "@lezer/common": "^1.0.0"
       },
       "peerDependencies": {
@@ -584,14 +584,14 @@
       }
     },
     "node_modules/@codemirror/commands": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.2.tgz",
-      "integrity": "sha512-s9lPVW7TxXrI/7voZ+HmD/yiAlwAYn9PH5SUVSUhsxXHhv4yl5eZ3KLntSoTynfdgVYM0oIpccQEWRBQgmNZyw==",
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.3.3.tgz",
+      "integrity": "sha512-dO4hcF0fGT9tu1Pj1D2PvGvxjeGkbC6RGcZw6Qs74TH+Ed1gw98jmUgd2axWvIZEqTeTuFrg1lEB1KV6cK9h1A==",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.2.0",
+        "@codemirror/state": "^6.4.0",
         "@codemirror/view": "^6.0.0",
-        "@lezer/common": "^1.0.0"
+        "@lezer/common": "^1.1.0"
       }
     },
     "node_modules/@codemirror/lang-javascript": {
@@ -651,9 +651,9 @@
       }
     },
     "node_modules/@codemirror/search": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.3.0.tgz",
-      "integrity": "sha512-rBhZxzT34CarfhgCZGhaLBScABDN3iqJxixzNuINp9lrb3lzm0nTpR77G1VrxGO3HOGK7j62jcJftQM7eCOIuw==",
+      "version": "6.5.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.6.tgz",
+      "integrity": "sha512-rpMgcsh7o0GuCDUXKPvww+muLA1pDJaFrpq/CCHtpQJYz8xopu4D1hPcKRoDD0YlF8gZaqTNIRa4VRBWyhyy7Q==",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -1499,9 +1499,9 @@
       }
     },
     "node_modules/@lezer/highlight": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.4.tgz",
-      "integrity": "sha512-IECkFmw2l7sFcYXrV8iT9GeY4W0fU4CxX0WMwhmhMIVjoDdD1Hr6q3G2NqVtLg/yVe5n7i4menG3tJ2r4eCrPQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.0.tgz",
+      "integrity": "sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -1538,6 +1538,24 @@
       "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.48.tgz",
       "integrity": "sha512-D5cAp2r0Eq9yN4lBNkVpHzoULHYeCQjLFF7PbD/LBBCuWXPIB4X3rbi12REvaCnEar/0UiSSfjIMWxFAw0vIJg==",
       "dev": true
+    },
+    "node_modules/@nanostores/persistent": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@nanostores/persistent/-/persistent-0.9.1.tgz",
+      "integrity": "sha512-ow57Hxm5VMaI5GHET/cVk8hX/iKMmbhcGrB9owfN8p8OHiiJgUlYxe1giacwlAALJXAh2t8bxXh42hHb64BCEA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "engines": {
+        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "nanostores": "^0.9.0"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3525,6 +3543,47 @@
         "node": ">=14"
       }
     },
+    "node_modules/@replit/codemirror-emacs": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@replit/codemirror-emacs/-/codemirror-emacs-6.0.1.tgz",
+      "integrity": "sha512-2WYkODZGH1QVAXWuOxTMCwktkoZyv/BjYdJi2A5w4fRrmOQFuIACzb6pO9dgU3J+Pm2naeiX2C8veZr/3/r6AA==",
+      "dev": true,
+      "peerDependencies": {
+        "@codemirror/autocomplete": "^6.0.2",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.1",
+        "@codemirror/view": "^6.3.0"
+      }
+    },
+    "node_modules/@replit/codemirror-vim": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@replit/codemirror-vim/-/codemirror-vim-6.1.0.tgz",
+      "integrity": "sha512-XATcrMBYphSgTTDHaL5cTdBKA+/kwg8x0kHpX9xFHkI8c2G9+nXdkIzFCtk76x1VDYQSlT6orNhudNt+9H9zOA==",
+      "dev": true,
+      "peerDependencies": {
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.1.0",
+        "@codemirror/search": "^6.2.0",
+        "@codemirror/state": "^6.0.1",
+        "@codemirror/view": "^6.0.3"
+      }
+    },
+    "node_modules/@replit/codemirror-vscode-keymap": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@replit/codemirror-vscode-keymap/-/codemirror-vscode-keymap-6.0.2.tgz",
+      "integrity": "sha512-j45qTwGxzpsv82lMD/NreGDORFKSctMDVkGRopaP+OrzSzv+pXDQuU3LnFvKpasyjVT0lf+PKG1v2DSCn/vxxg==",
+      "dev": true,
+      "peerDependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/@rollup/plugin-inject": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
@@ -3954,6 +4013,39 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
       "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==",
       "dev": true
+    },
+    "node_modules/@strudel/codemirror": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@strudel/codemirror/-/codemirror-1.0.1.tgz",
+      "integrity": "sha512-m0fQtODjl8vhnxAPkEcvO1bozp6c2jhIN8osEbmK3A0ZzD9YkgkPfdmiAsdQw9pFFnMNQUb3AePJh1XnHlc6vg==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.11.1",
+        "@codemirror/commands": "^6.3.3",
+        "@codemirror/lang-javascript": "^6.2.1",
+        "@codemirror/language": "^6.10.0",
+        "@codemirror/search": "^6.5.5",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/highlight": "^1.2.0",
+        "@nanostores/persistent": "^0.9.1",
+        "@replit/codemirror-emacs": "^6.0.1",
+        "@replit/codemirror-vim": "^6.1.0",
+        "@replit/codemirror-vscode-keymap": "^6.0.2",
+        "@strudel/core": "1.0.1",
+        "@uiw/codemirror-themes": "^4.21.21",
+        "@uiw/codemirror-themes-all": "^4.21.21",
+        "nanostores": "^0.9.5"
+      }
+    },
+    "node_modules/@strudel/codemirror/node_modules/@strudel/core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@strudel/core/-/core-1.0.1.tgz",
+      "integrity": "sha512-4Ei55Gj5r+XCLc3L5G8YulnFvyYMZVM21NCnH6gY5NNw/dDZujucS//QoPzrp0z9zrnrIIRVxjfGnjYBdIrLbA==",
+      "dev": true,
+      "dependencies": {
+        "fraction.js": "^4.3.7"
+      }
     },
     "node_modules/@strudel/core": {
       "version": "1.0.0",
@@ -5212,6 +5304,489 @@
         "@codemirror/search": ">=6.0.0",
         "@codemirror/state": ">=6.0.0",
         "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-abcdef": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-abcdef/-/codemirror-theme-abcdef-4.21.22.tgz",
+      "integrity": "sha512-8I+RPq9lUaveCtAM+fR5ANWS6y5mvIsJOrOcxrA37QSmOMC5qWfjEy8AMkDHyStx8hNe5urJ5SOIO/ZyzPOfIA==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-abyss": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-abyss/-/codemirror-theme-abyss-4.21.22.tgz",
+      "integrity": "sha512-VTZi5UDvp6Ub5GfuTzVBOfetzpWDXo0RxK+Td/QZfGaRkvwZICbGgGGJjqpitA/3dVdPOZ+C4Wdk/8I4uCRNtQ==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-androidstudio": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-androidstudio/-/codemirror-theme-androidstudio-4.21.22.tgz",
+      "integrity": "sha512-ImfX/krtnX0tOm/uf4XbTbxkZnDvM5by2pVM1IQpiy26FLUmylKjq3GyuKEMw4rerr8ndd9ezc+e+PLZPrvycg==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-andromeda": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-andromeda/-/codemirror-theme-andromeda-4.21.22.tgz",
+      "integrity": "sha512-wHB+WE54Fy9mTE6B1B3jRA3DGRE7k3AhVfVB3KNUxy6pliklvkKnrMF2z+kbe1oHqz1mmlZxmiqc5X1j77egbA==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-atomone": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-atomone/-/codemirror-theme-atomone-4.21.22.tgz",
+      "integrity": "sha512-OlrlMcEYDqRQMjXNIQklUyppNt2IvroIR/jRamNg5wq9M0KoprJyxhACY1NZbaKXEfvO/KUeFBIWxEpmnftkGA==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-aura": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-aura/-/codemirror-theme-aura-4.21.22.tgz",
+      "integrity": "sha512-8te279BfHYwpH+K0cLqt/aaYAwbC+k8ucRitmtoCOjbi5VSMdUKD9pb3Pr4QtrDzpkprhW5Jug3nNkdZDN4Y5Q==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-basic": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-basic/-/codemirror-theme-basic-4.21.22.tgz",
+      "integrity": "sha512-HillAFFqra1i+XnHA17Y6Od4dFuqMel2uoZ9BBz5wGvpI5msk7I6qH2pKQ14/wPMNYC0JsJ1zP2DnZN5TYctKA==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-bbedit": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-bbedit/-/codemirror-theme-bbedit-4.21.22.tgz",
+      "integrity": "sha512-OQEZfO36pMSg2EFl2pD2HHrQXbiXqcTaLtbGQ78MHiZ6OqvGDkQ0djqf/n4/1e6P76EczHYiMdD5TKphblVbLA==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-bespin": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-bespin/-/codemirror-theme-bespin-4.21.22.tgz",
+      "integrity": "sha512-mdWB76nvX/xqbodQzr4cVEXXlJRSokSyoFHei/tICaCyt6U6zJ0WA9Wem1ObGpgobW+nS70Ys0SrQHtKJWU2pg==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-console": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-console/-/codemirror-theme-console-4.21.22.tgz",
+      "integrity": "sha512-5rRNWbqdchAK2Buxt5+fx7Tbiu9aIuXfngvH8xGcQNRg45idARivb748fpSiFbWTkRCwJjR0XRDsLiUBXKn9fA==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-copilot": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-copilot/-/codemirror-theme-copilot-4.21.22.tgz",
+      "integrity": "sha512-Ws6l2mKyWFhELAAehTJ4eThkaI75WFTlnowUY5KcsXrJ8RTcbZRvflE1KDgey/YL40IkjVKdqd+OfpIpGYBi+Q==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-darcula": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-darcula/-/codemirror-theme-darcula-4.21.22.tgz",
+      "integrity": "sha512-NMX16uOh5QAt0hXIUWWCuWNj2W1EXGieEEmbWYgz1uauEESp7GLe9u7dvNrilkaVfsoBMKm40TWQXhK1k+pT4Q==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-dracula": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-dracula/-/codemirror-theme-dracula-4.21.22.tgz",
+      "integrity": "sha512-anNraklIvSvlvuAowDKlqmhdjwNXL73lMEkoart3g2vwKzw65CNSc2B+sxaA535YFUyhj0p+OMw0N/7AgbqOyg==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-duotone": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-duotone/-/codemirror-theme-duotone-4.21.22.tgz",
+      "integrity": "sha512-xv/l5g/Ar6jrWYV2OEXUWH6U0Bje3tL/iyQYlwdElMnaz+CzQCHMkPRAoWE2w6NYZm5PZAM8DS3cwsWfZ2Kg5Q==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-eclipse": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-eclipse/-/codemirror-theme-eclipse-4.21.22.tgz",
+      "integrity": "sha512-CizcwzegkuwX6eBSP8s/7q+Yh3F13okHhKaIwQtLFLjDrrU/rCOgIx9QGamOBU5HlcuHtolotn/hqG6VsA/SUg==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-github": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-github/-/codemirror-theme-github-4.21.22.tgz",
+      "integrity": "sha512-tCfeA2LXA1sseBccxnCoCJQfekU0J8Se/47UkqoiqIwdXwOr92s4oNTk7y9XWH06Pq+N1KETfjlw0ztNxbNmFA==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-gruvbox-dark": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-gruvbox-dark/-/codemirror-theme-gruvbox-dark-4.21.22.tgz",
+      "integrity": "sha512-jIhRYK1XMfztYtA6M9boUNTMeQUz2LYmnlqhorIuB2iI6esbJIua4CBjSWoKgDN47i96V9ZEYjO9ukNkNXImPg==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-kimbie": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-kimbie/-/codemirror-theme-kimbie-4.21.22.tgz",
+      "integrity": "sha512-GkCebXPHlT3qJ8gqa4ShT/Qv3J/IbXlZ5HBsVRfj+tRBCXP+hU/SYh+1aCTFPof6pQ1lSbiys5k0BlsWuA+SLw==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-material": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-material/-/codemirror-theme-material-4.21.22.tgz",
+      "integrity": "sha512-gsJRJaTMrGg4ge1RZnRMBGlvjseHvVikXyqTqUbiXD0Esn1D6tc+8F+hkn1UvbBLf4DPyr4UJnjiBMZR+Sn5og==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-monokai": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-monokai/-/codemirror-theme-monokai-4.21.22.tgz",
+      "integrity": "sha512-hfuS5O0LBdpoG4sM10uyFdwdLVEp3InczSRiaK5q45EBFvsy7amAsRib47V4e466qOSilZJfaUB3969j+sVBnQ==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-monokai-dimmed": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-monokai-dimmed/-/codemirror-theme-monokai-dimmed-4.21.22.tgz",
+      "integrity": "sha512-DbPF9IlBgn89V8Z138hPgQ/OjH66PZiuOdqIEFyYSiEqCKz/iqmTnMTEU0DCyges230Mg77sKKQoSqsGBgchJw==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-noctis-lilac": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-noctis-lilac/-/codemirror-theme-noctis-lilac-4.21.22.tgz",
+      "integrity": "sha512-vXgcaqjQUmM0Qd2SdpEUG/xYQLP1Yw4hKRMm37ODv3nsZpTLbku54cMu7R3oMUXLW2IXLs6pbio1/fPqTr7J5A==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-nord": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-nord/-/codemirror-theme-nord-4.21.22.tgz",
+      "integrity": "sha512-guFrL32ksumJWlU5wWqRwRTBnLJ/J85/zDqhkjNyCJbls4Sd9brK+/jaKC2BR6sSieCmD9Ea8uo6if8NYvrFDw==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-okaidia": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-okaidia/-/codemirror-theme-okaidia-4.21.22.tgz",
+      "integrity": "sha512-8IBKHQX5XNNlRF72iMhjGn2Wd9gg6psCFdOzoMB3zAxY0KD9PWftLtEl11yy1jFr6wzRpxGCHY95og0Ka+F1Aw==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-quietlight": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-quietlight/-/codemirror-theme-quietlight-4.21.22.tgz",
+      "integrity": "sha512-akEE2O9hTp/FMqg4IuXv5zGqX8sbl9lrkKDqbV6jwPtFk62mWBmcx+I2LejENqpOLkAIXtaGdbkcuf34tgjr0g==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-red": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-red/-/codemirror-theme-red-4.21.22.tgz",
+      "integrity": "sha512-x3wN5Vw7C+Z7Yv+4ZMPa8XiNVzJJ3dkjde+n8eULdXtAxivhzqd4yYRhvi8NkcYjBanakUtNMZxHG3vHAd2GnQ==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-solarized": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-solarized/-/codemirror-theme-solarized-4.21.22.tgz",
+      "integrity": "sha512-YvgVzyU8S1mNT7V7dLC8CdhZsurXTn6xDcn8t/CgFwa9g7zPJULYT3+/oB2hwid7jHFZhxn1f9QpVkVasHXjzw==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-sublime": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-sublime/-/codemirror-theme-sublime-4.21.22.tgz",
+      "integrity": "sha512-IQKKX7dwJGxxkWJSJEmVJAokCah8LMWlelYPNM+rfpBRqAv0i+HvIYKTJjO6r5sqNkoR3w9fIjoyhBtXq1V1Hw==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-tokyo-night": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tokyo-night/-/codemirror-theme-tokyo-night-4.21.22.tgz",
+      "integrity": "sha512-yaWelCqmOksuAbl8oYXjP/LqTj6KW2c7g9V9kL6NIb5LAnGr9DRFM3FKPpdylB4Ifx+e4QkcQBmY9/kSuPtf+g==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-tokyo-night-day": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tokyo-night-day/-/codemirror-theme-tokyo-night-day-4.21.22.tgz",
+      "integrity": "sha512-QMN7yak7Apvw9CXVEKNGYYLNmZUesiSMeYRCqkKTt5TOygEDT4oWW2tJX8WNyODSJZUihUqPbTvRufBUepPN6w==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-tokyo-night-storm": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tokyo-night-storm/-/codemirror-theme-tokyo-night-storm-4.21.22.tgz",
+      "integrity": "sha512-gOSOI3Hrz8xjuUad/WPaAlb0y6b+ca2MKZ46gHa5ZA/jlqpKGTVcU3xgMr09Bjg546IbvM4XiKSgq3ojml4djg==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-tomorrow-night-blue": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tomorrow-night-blue/-/codemirror-theme-tomorrow-night-blue-4.21.22.tgz",
+      "integrity": "sha512-qDnskMEfhPxBG2Bb78XyxTUthhA99XQznCYo8ktX21XQFInn5NeWPQDk/eja3v4db8l8ymp1XvP0P7HuZO86pg==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-vscode": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-vscode/-/codemirror-theme-vscode-4.21.22.tgz",
+      "integrity": "sha512-8E7txA1IFCB+a38tovL7ZoKLC1mDfA3X83XYU+KQoaxyPzImm8aJLVDghHH8EUF0gOdJWPSW13OPVAGCayBKCA==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-white": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-white/-/codemirror-theme-white-4.21.22.tgz",
+      "integrity": "sha512-I+uBUBYX6wJbmu5QkU75JiUQ+qWT25XvPFvWXQE7KHLRt/3/P3/ptXWcO5vTRxRov3+8/tp5hfbSC4zvzJesEg==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-theme-xcode": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-xcode/-/codemirror-theme-xcode-4.21.22.tgz",
+      "integrity": "sha512-VmLMMKrE1wInBPixuzC6RdcLnrRxPUWTVnMpmt3CR1Y8jQqur2eZZ1XAsaRgIqIqa7y0EO0nvpnMav6L8QYCfQ==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-themes": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.21.22.tgz",
+      "integrity": "sha512-oRMNtDmD6ER0EH2/NKGbrUzeRJbZ/4+GE3/9OItaAGhdsd2V33WGqVX7QwXsjLNhpNfscbVKB3PYLyRooBdlfg==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/language": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/codemirror-themes-all": {
+      "version": "4.21.22",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes-all/-/codemirror-themes-all-4.21.22.tgz",
+      "integrity": "sha512-6PvBAuBc2PjTeJ+eju7DWYdNRoNc3z63+efo4fRvVsV5U42VqdYRmNGThfb+Wi2E5oGdGYb3wNt8r7efDIV3Kw==",
+      "dev": true,
+      "dependencies": {
+        "@uiw/codemirror-theme-abcdef": "4.21.22",
+        "@uiw/codemirror-theme-abyss": "4.21.22",
+        "@uiw/codemirror-theme-androidstudio": "4.21.22",
+        "@uiw/codemirror-theme-andromeda": "4.21.22",
+        "@uiw/codemirror-theme-atomone": "4.21.22",
+        "@uiw/codemirror-theme-aura": "4.21.22",
+        "@uiw/codemirror-theme-basic": "4.21.22",
+        "@uiw/codemirror-theme-bbedit": "4.21.22",
+        "@uiw/codemirror-theme-bespin": "4.21.22",
+        "@uiw/codemirror-theme-console": "4.21.22",
+        "@uiw/codemirror-theme-copilot": "4.21.22",
+        "@uiw/codemirror-theme-darcula": "4.21.22",
+        "@uiw/codemirror-theme-dracula": "4.21.22",
+        "@uiw/codemirror-theme-duotone": "4.21.22",
+        "@uiw/codemirror-theme-eclipse": "4.21.22",
+        "@uiw/codemirror-theme-github": "4.21.22",
+        "@uiw/codemirror-theme-gruvbox-dark": "4.21.22",
+        "@uiw/codemirror-theme-kimbie": "4.21.22",
+        "@uiw/codemirror-theme-material": "4.21.22",
+        "@uiw/codemirror-theme-monokai": "4.21.22",
+        "@uiw/codemirror-theme-monokai-dimmed": "4.21.22",
+        "@uiw/codemirror-theme-noctis-lilac": "4.21.22",
+        "@uiw/codemirror-theme-nord": "4.21.22",
+        "@uiw/codemirror-theme-okaidia": "4.21.22",
+        "@uiw/codemirror-theme-quietlight": "4.21.22",
+        "@uiw/codemirror-theme-red": "4.21.22",
+        "@uiw/codemirror-theme-solarized": "4.21.22",
+        "@uiw/codemirror-theme-sublime": "4.21.22",
+        "@uiw/codemirror-theme-tokyo-night": "4.21.22",
+        "@uiw/codemirror-theme-tokyo-night-day": "4.21.22",
+        "@uiw/codemirror-theme-tokyo-night-storm": "4.21.22",
+        "@uiw/codemirror-theme-tomorrow-night-blue": "4.21.22",
+        "@uiw/codemirror-theme-vscode": "4.21.22",
+        "@uiw/codemirror-theme-white": "4.21.22",
+        "@uiw/codemirror-theme-xcode": "4.21.22",
+        "@uiw/codemirror-themes": "4.21.22"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
       }
     },
     "node_modules/@uiw/react-codemirror": {
@@ -17921,6 +18496,7 @@
         "@radix-ui/react-toast": "^1.1.3",
         "@radix-ui/react-toggle": "^1.0.2",
         "@radix-ui/react-tooltip": "^1.0.5",
+        "@strudel/codemirror": "^1.0.0",
         "@strudel/core": "^1.0.0",
         "@strudel/midi": "^1.0.0",
         "@strudel/mini": "^1.0.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -46,6 +46,7 @@
     "@radix-ui/react-tooltip": "^1.0.5",
     "@strudel/core": "^1.0.0",
     "@strudel/midi": "^1.0.0",
+    "@strudel/codemirror": "^1.0.0",
     "@strudel/mini": "^1.0.0",
     "@strudel/osc": "^1.0.0",
     "@strudel/serial": "^1.0.0",

--- a/packages/web/src/components/editor.tsx
+++ b/packages/web/src/components/editor.tsx
@@ -19,6 +19,9 @@ import CodeMirror, {
 import React, { useEffect, useState } from "react";
 import { yCollab } from "y-codemirror.next";
 import { UndoManager } from "yjs";
+import { highlightExtension } from '@strudel/codemirror';
+
+console.log('highlightExtension', highlightExtension);
 
 const defaultLanguage = "javascript";
 const langByTarget = langByTargetUntyped as { [lang: string]: string };
@@ -172,6 +175,7 @@ export const Editor = React.forwardRef(
       baseTheme,
       flokSetup(document, { readOnly }),
       languageExtension(),
+      highlightExtension,
       readOnly ? EditorState.readOnly.of(true) : [],
       // toggle linenumbers on/off
       toggleWith('shift-ctrl-l', lineNumbers()),

--- a/packages/web/src/components/editor.tsx
+++ b/packages/web/src/components/editor.tsx
@@ -21,8 +21,6 @@ import { yCollab } from "y-codemirror.next";
 import { UndoManager } from "yjs";
 import { highlightExtension } from '@strudel/codemirror';
 
-console.log('highlightExtension', highlightExtension);
-
 const defaultLanguage = "javascript";
 const langByTarget = langByTargetUntyped as { [lang: string]: string };
 const langExtensionsByLanguage: { [lang: string]: any } = {

--- a/packages/web/src/hooks/use-strudel.tsx
+++ b/packages/web/src/hooks/use-strudel.tsx
@@ -5,16 +5,21 @@ import { ReactCodeMirrorRef } from "@uiw/react-codemirror";
 
 export function useStrudel(
   session: Session | null,
-  onError?: (err: unknown) => void,
-  onWarning?: (msg: string) => void,
-  editorRefs?: React.RefObject<ReactCodeMirrorRef>[]
+  onError: (err: unknown) => void,
+  onWarning: (msg: string) => void,
+  editorRefs: React.RefObject<ReactCodeMirrorRef>[]
 ) {
   return useWebTarget<StrudelWrapper>(
     "strudel",
     session,
     async () => {
       console.log("Create StrudelWrapper");
-      const strudel = new StrudelWrapper({ onError, onWarning, editorRefs });
+      const strudel = new StrudelWrapper({
+        onError,
+        onWarning,
+        editorRefs,
+        session,
+      });
 
       console.log("Import Strudel modules");
       await strudel.importModules();

--- a/packages/web/src/hooks/use-strudel.tsx
+++ b/packages/web/src/hooks/use-strudel.tsx
@@ -1,18 +1,20 @@
 import { useWebTarget } from "@/hooks/use-web-target";
 import { StrudelWrapper } from "@/lib/strudel-wrapper";
 import type { Session } from "@flok-editor/session";
+import { ReactCodeMirrorRef } from "@uiw/react-codemirror";
 
 export function useStrudel(
   session: Session | null,
   onError?: (err: unknown) => void,
-  onWarning?: (msg: string) => void
+  onWarning?: (msg: string) => void,
+  editorRefs?: React.RefObject<ReactCodeMirrorRef>[]
 ) {
   return useWebTarget<StrudelWrapper>(
     "strudel",
     session,
     async () => {
       console.log("Create StrudelWrapper");
-      const strudel = new StrudelWrapper({ onError, onWarning });
+      const strudel = new StrudelWrapper({ onError, onWarning, editorRefs });
 
       console.log("Import Strudel modules");
       await strudel.importModules();

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -32,3 +32,7 @@
   text-shadow: -1px -1px 0 #000, 0 -1px 0 #000, 1px -1px 0 #000, 1px 0 0 #000,
     1px 1px 0 #000, 0 1px 0 #000, -1px 1px 0 #000, -1px 0 0 #000;
 }
+
+:root {
+  --foreground: #fff;
+}

--- a/packages/web/src/lib/strudel-wrapper.ts
+++ b/packages/web/src/lib/strudel-wrapper.ts
@@ -17,6 +17,7 @@ import {
   registerSynthSounds,
 } from "@strudel/webaudio";
 import { registerSoundfonts } from "@strudel/soundfonts";
+import { updateMiniLocations } from "@strudel/codemirror";
 
 export type ErrorHandler = (error: string) => void;
 
@@ -38,6 +39,7 @@ export class StrudelWrapper {
     this._docPatterns = {};
     this._onError = onError || (() => {});
     this._onWarning = onWarning || (() => {});
+    console.log("strudel", this);
   }
 
   async importModules() {
@@ -68,7 +70,14 @@ export class StrudelWrapper {
   async initialize() {
     this._repl = repl({
       defaultOutput: webaudioOutput,
-      afterEval: () => {},
+      afterEval: (options: any) => {
+        console.log("strudel eval", options);
+        const miniLocations = options.meta?.miniLocations;
+        console.log("miniLocations", miniLocations, updateMiniLocations);
+        // TODO: find way to get a reference to the current editor
+        /*updateMiniLocations(editor, miniLocations); */
+        // TODO: find a good place to run an animation loop to call highlightMiniLocations(editor, time, haps);
+      },
       beforeEval: () => {},
       onSchedulerError: (e: unknown) => this._onError(`${e}`),
       onEvalError: (e: unknown) => this._onError(`${e}`),

--- a/packages/web/src/lib/strudel.d.ts
+++ b/packages/web/src/lib/strudel.d.ts
@@ -10,3 +10,4 @@ declare module "@strudel/transpiler";
 declare module "@strudel/webaudio";
 declare module "@strudel/webaudio/scheduler.mjs";
 declare module "@strudel/webaudio/webaudio.mjs";
+declare module "@strudel/codemirror";

--- a/packages/web/src/routes/session.tsx
+++ b/packages/web/src/routes/session.tsx
@@ -345,7 +345,8 @@ export default function SessionPage() {
   useStrudel(
     session,
     (err) => handleWebError("Strudel", err),
-    (msg) => handleWebWarning("Strudel", msg)
+    (msg) => handleWebWarning("Strudel", msg),
+    editorRefs
   );
   useMercury(
     session,

--- a/packages/web/src/settings.json
+++ b/packages/web/src/settings.json
@@ -29,7 +29,7 @@
     "mercury": "silence",
     "mercury-web": "silence",
     "hydra": "hush()",
-    "strudel": "\"~\".out()",
+    "strudel": "silence",
     "sardine": "panic()"
   },
   "webTargets": ["hydra", "strudel", "mercury-web"],


### PR DESCRIPTION
aiming to add highlighting support to flok for strudel editors.

- [x] add `@strudel/codemirror` package
- [x] get a reference to the current codemirror instance in `afterEval`
- [x] add an animation frame loop to highlight active haps for each strudel editor
