### PR TITLE
Add the hydra plugin to strudel instances

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4056,6 +4056,18 @@
         "@strudel/core": "1.1.0"
       }
     },
+    "node_modules/@strudel/hydra": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@strudel/hydra/-/hydra-1.1.0.tgz",
+      "integrity": "sha512-8vCsXWjQSAP4dLppHA4Pc6eC2lBJSJtcaA79BBIjrbmgeNB7Zkm+s03uUtg9O/UBP/JTOxUPlpscHZ33nxS1ng==",
+      "dev": true,
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/core": "1.1.0",
+        "@strudel/draw": "1.1.0",
+        "hydra-synth": "^1.3.29"
+      }
+    },
     "node_modules/@strudel/midi": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@strudel/midi/-/midi-1.1.0.tgz",
@@ -18596,6 +18608,7 @@
         "@replit/codemirror-vim": "^6.2.1",
         "@strudel/codemirror": "^1.1.0",
         "@strudel/core": "^1.1.0",
+        "@strudel/hydra": "^1.1.0",
         "@strudel/midi": "^1.1.0",
         "@strudel/mini": "^1.1.0",
         "@strudel/osc": "^1.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -63,6 +63,7 @@
     "@strudel/tonal": "^1.1.0",
     "@strudel/transpiler": "^1.1.0",
     "@strudel/webaudio": "^1.1.0",
+    "@strudel/hydra": "^1.1.0",
     "@types/express": "^4.17.21",
     "@types/p5": "^1.7.6",
     "@types/react": "^18.2.43",

--- a/packages/web/src/lib/strudel-wrapper.ts
+++ b/packages/web/src/lib/strudel-wrapper.ts
@@ -58,6 +58,7 @@ export class StrudelWrapper {
       import("@strudel/serial"),
       import("@strudel/soundfonts"),
       import("@strudel/webaudio"),
+      import("@strudel/hydra"),
       controls
     );
     try {

--- a/packages/web/src/lib/strudel.d.ts
+++ b/packages/web/src/lib/strudel.d.ts
@@ -12,3 +12,4 @@ declare module "@strudel/transpiler";
 declare module "@strudel/webaudio";
 declare module "@strudel/webaudio/scheduler.mjs";
 declare module "@strudel/webaudio/webaudio.mjs";
+declare module "@strudel/hydra";


### PR DESCRIPTION
Currently there is no way to have hydra be influenced by the strudel audio output.

With importing the hydra plugin into strudel, you now can!
<img width="1339" alt="image" src="https://github.com/user-attachments/assets/280b4768-1498-4510-b0b0-d00d7f0ace12">
There are some downsides of course, foremost, that you have to write hydra code in strudel :/
And you kinda use hydra in strudel to, which probably has some more limitations.