### PR TITLE
Add angle brackets to tidal language autoclose

### DIFF
--- a/packages/lang-tidal/src/index.ts
+++ b/packages/lang-tidal/src/index.ts
@@ -1,7 +1,7 @@
 import { StreamLanguage } from "@codemirror/language";
-import { haskell } from "@codemirror/legacy-modes/mode/haskell";
+import { tidalLanguage } from "./tidal";
 import { indentation } from "./indentation";
 
 export function tidal() {
-  return [indentation(), StreamLanguage.define(haskell)];
+  return [indentation(), StreamLanguage.define(tidalLanguage)];
 }

--- a/packages/lang-tidal/src/tidal.ts
+++ b/packages/lang-tidal/src/tidal.ts
@@ -1,0 +1,10 @@
+import { haskell } from "@codemirror/legacy-modes/mode/haskell";
+
+export const tidalLanguage = {
+    ...haskell,
+    name: "tidal",
+    languageData: {
+        ...haskell.languageData,
+        closeBrackets: {brackets: ["(", "[", "{", "<", '"'], before: ')]}>"'}
+    }
+}


### PR DESCRIPTION
This comes with the downside of creating a closing bracket when typing '|<', but allows for automatic wrapping of selections, which I think occurs much more commonly.