### PR TITLE
fix: stuck flashes

### DIFF
--- a/packages/cm-eval/lib/flashField.ts
+++ b/packages/cm-eval/lib/flashField.ts
@@ -3,8 +3,6 @@ import { StateField, StateEffect } from "@codemirror/state";
 
 type FlashRange = [number, number];
 
-let timeoutId: any;
-
 export const setFlash = StateEffect.define<FlashRange | null>();
 
 const defaultStyle = {
@@ -23,9 +21,8 @@ export const flash = (
   timeout: number = 150
 ) => {
   if (from === null || to === null) return;
-  clearTimeout(timeoutId);
   view.dispatch({ effects: setFlash.of([from, to]) });
-  timeoutId = setTimeout(() => {
+  setTimeout(() => {
     view.dispatch({ effects: setFlash.of(null) });
   }, timeout);
 };


### PR DESCRIPTION
removed the timeout clear, because it would overwrite currently active timeouts, leading to stuck flash highlights. without clearing, the worst thing that can happen is that you evaluate twice within 150 ms and get a slightly shorter flash

fixes https://github.com/munshkr/flok/issues/296