### PR TITLE
Add "npm run check"

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "url": "git+https://github.com/munshkr/flok.git"
   },
   "scripts": {
-    "build": "lerna run build"
+    "build": "lerna run build",
+    "check": "lerna run check"
   },
   "keywords": [
     "codemirror",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -18,7 +18,8 @@
     "dev": "cross-env NODE_ENV=development node ./bin/flok-web.js",
     "prebuild": "node script/prebuild.js",
     "build": "npm run prebuild && tsc && vite build",
-    "start": "node ./bin/flok-web.js"
+    "start": "node ./bin/flok-web.js",
+    "check": "tsc --noEmit"
   },
   "dependencies": {
     "@flok-editor/server-middleware": "^1.0.1",


### PR DESCRIPTION
Adds a "check" script to the "web" package.

You can run `npm run check` from root or from the web folder to do a typecheck, without needing to do a full build. Might seem pointless but I tend to look inside `package.json` to see if there's an easy way to do a quick check, so it would make it more discoverable for people like me :)