### PR TITLE
Fix for comment keymap on spanish keyboards

### DIFF
--- a/packages/web/src/components/editor.tsx
+++ b/packages/web/src/components/editor.tsx
@@ -72,11 +72,11 @@ const panicKeymap = (
 const extraKeymap = () => {
   return keymap.of([
     // fixes the Cmd/Alt-/ issue for Spanish keyboards
-    { key: 'Shift-Cmd-7', run: toggleLineComment },
-    { key: 'Shift-Alt-7', run: toggleLineComment },
-    { key: 'Alt-/', run: toggleLineComment },
-    { key: 'Ctrl-/', run: toggleLineComment },
-  ])
+    { key: "Shift-Cmd-7", run: toggleLineComment },
+    { key: "Shift-Alt-7", run: toggleLineComment },
+    { key: "Alt-/", run: toggleLineComment },
+    { key: "Ctrl-/", run: toggleLineComment },
+  ]);
 };
 
 interface FlokSetupOptions {

--- a/packages/web/src/components/editor.tsx
+++ b/packages/web/src/components/editor.tsx
@@ -69,7 +69,7 @@ const panicKeymap = (
     : [];
 };
 
-const extraKeymap = ( doc: Document ) => {
+const extraKeymap = () => {
   return keymap.of([
     // fixes the Cmd/Alt-/ issue for Spanish keyboards
     { key: 'Shift-Cmd-7', run: toggleLineComment },
@@ -99,7 +99,7 @@ const flokSetup = (
     remoteEvalFlash(doc),
     Prec.high(evalKeymap(doc, { defaultMode, web })),
     panicKeymap(doc),
-    extraKeymap(doc),
+    extraKeymap(),
     yCollab(text, doc.session.awareness, {
       undoManager,
       hideCaret: readOnly,

--- a/packages/web/src/components/editor.tsx
+++ b/packages/web/src/components/editor.tsx
@@ -39,6 +39,7 @@ import React, { useEffect, useState } from "react";
 import { yCollab } from "y-codemirror.next";
 import { UndoManager } from "yjs";
 import themes from "@/lib/themes";
+import { toggleLineComment } from "@codemirror/commands";
 
 const defaultLanguage = "javascript";
 const langByTarget = langByTargetUntyped as { [lang: string]: string };
@@ -68,6 +69,16 @@ const panicKeymap = (
     : [];
 };
 
+const extraKeymap = ( doc: Document ) => {
+  return keymap.of([
+    // fixes the Cmd/Alt-/ issue for Spanish keyboards
+    { key: 'Shift-Cmd-7', run: toggleLineComment },
+    { key: 'Shift-Alt-7', run: toggleLineComment },
+    { key: 'Alt-/', run: toggleLineComment },
+    { key: 'Ctrl-/', run: toggleLineComment },
+  ])
+};
+
 interface FlokSetupOptions {
   readOnly?: boolean;
 }
@@ -88,6 +99,7 @@ const flokSetup = (
     remoteEvalFlash(doc),
     Prec.high(evalKeymap(doc, { defaultMode, web })),
     panicKeymap(doc),
+    extraKeymap(doc),
     yCollab(text, doc.session.awareness, {
       undoManager,
       hideCaret: readOnly,


### PR DESCRIPTION
I've had several encounters with people who have a spanish keyboard layout, where the `cmd-/` keymap to (un)comment doesn't work, because they need to type `cmd` `shift` `7`. 

I'm proposing this fix (that worked for me in the mercury editor on my site) where I just added the actual keycombination `shift-cmd-7` and `shift-alt-7` (as alternative).

I've also added `alt-/` and `ctrl-/` as extra alternatives. The `alt-/` mainly because I'm used to using alt in Mercury to avoid clashes with other commands. The `ctrl-/` is maybe not so necessary but also doesn't hurt I guess.

My fix here hasn't been tested on a Spanish keyboard yet, so I'm happy to hear feedback from users with such a keyboard.