### PR TITLE
No Auto Indentation for Mercury(-Web)

### DIFF
--- a/packages/web/src/components/editor.tsx
+++ b/packages/web/src/components/editor.tsx
@@ -74,13 +74,11 @@ const panicKeymap = (
 const autoIndentKeymap = (
   doc: Document
 ) => {
-  const noIndent = noAutoIndent.indexOf(doc.target) > -1;
-  console.log(noIndent);
-
+  // if any of the targets is part of the noAutoIndent setting in settings.json
+  const noIndent = noAutoIndent.includes(doc.target);
+  // overwrite the Enter with insertNewline
   return noIndent ? Prec.high(
-    keymap.of([
-      { key: 'Enter', run: insertNewline }
-    ])
+    keymap.of([{ key: 'Enter', run: insertNewline }])
   ) : [];
 };
 

--- a/packages/web/src/components/editor.tsx
+++ b/packages/web/src/components/editor.tsx
@@ -71,15 +71,13 @@ const panicKeymap = (
 };
 
 // overwrites the default insertNewlineAndIndent command on Enter
-const autoIndentKeymap = (
-  doc: Document
-) => {
+const autoIndentKeymap = (doc: Document) => {
   // if any of the targets is part of the noAutoIndent setting in settings.json
   const noIndent = noAutoIndent.includes(doc.target);
   // overwrite the Enter with insertNewline
-  return noIndent ? Prec.high(
-    keymap.of([{ key: 'Enter', run: insertNewline }])
-  ) : [];
+  return noIndent
+    ? Prec.high(keymap.of([{ key: "Enter", run: insertNewline }]))
+    : [];
 };
 
 interface FlokSetupOptions {

--- a/packages/web/src/components/editor.tsx
+++ b/packages/web/src/components/editor.tsx
@@ -16,6 +16,7 @@ import {
   langByTarget as langByTargetUntyped,
   panicCodes as panicCodesUntyped,
   targetsWithDocumentEvalMode,
+  noAutoIndent,
   webTargets,
 } from "@/settings.json";
 import { javascript } from "@codemirror/lang-javascript";
@@ -70,12 +71,17 @@ const panicKeymap = (
 };
 
 // overwrites the default insertNewlineAndIndent command on Enter
-const noAutoIndent = () => {
-  return Prec.high(
+const autoIndentKeymap = (
+  doc: Document
+) => {
+  const noIndent = noAutoIndent.indexOf(doc.target) > -1;
+  console.log(noIndent);
+
+  return noIndent ? Prec.high(
     keymap.of([
       { key: 'Enter', run: insertNewline }
     ])
-  )
+  ) : [];
 };
 
 interface FlokSetupOptions {
@@ -98,6 +104,7 @@ const flokSetup = (
     remoteEvalFlash(doc),
     Prec.high(evalKeymap(doc, { defaultMode, web })),
     panicKeymap(doc),
+    autoIndentKeymap(doc),
     yCollab(text, doc.session.awareness, {
       undoManager,
       hideCaret: readOnly,
@@ -111,7 +118,6 @@ export interface EditorSettings {
   fontFamily: string;
   lineNumbers: boolean;
   wrapText: boolean;
-  autoIndent: boolean;
   vimMode: boolean;
 }
 
@@ -137,13 +143,12 @@ export const Editor = ({ document, settings, ref, ...props }: EditorProps) => {
     return null;
   }
 
-  const { theme, fontFamily, lineNumbers, wrapText, vimMode, autoIndent } = {
+  const { theme, fontFamily, lineNumbers, wrapText, vimMode } = {
     theme: "dracula",
     fontFamily: "IBM Plex Mono",
     lineNumbers: false,
     wrapText: false,
     vimMode: false,
-    autoIndent: false,
     ...settings,
   };
 
@@ -193,7 +198,6 @@ export const Editor = ({ document, settings, ref, ...props }: EditorProps) => {
     lineNumbers ? lineNumbersExtension() : [],
     vimMode ? vim() : [],
     wrapText ? EditorView.lineWrapping : [],
-    autoIndent ? [] : noAutoIndent(),
   ];
 
   // If it's read-only, put a div in front of the editor so that the user

--- a/packages/web/src/components/editor.tsx
+++ b/packages/web/src/components/editor.tsx
@@ -39,6 +39,7 @@ import React, { useEffect, useState } from "react";
 import { yCollab } from "y-codemirror.next";
 import { UndoManager } from "yjs";
 import themes from "@/lib/themes";
+import { insertNewline } from "@codemirror/commands";
 
 const defaultLanguage = "javascript";
 const langByTarget = langByTargetUntyped as { [lang: string]: string };
@@ -66,6 +67,15 @@ const panicKeymap = (
         })),
       ])
     : [];
+};
+
+// overwrites the default insertNewlineAndIndent command on Enter
+const noAutoIndent = () => {
+  return Prec.high(
+    keymap.of([
+      { key: 'Enter', run: insertNewline }
+    ])
+  )
 };
 
 interface FlokSetupOptions {
@@ -101,6 +111,7 @@ export interface EditorSettings {
   fontFamily: string;
   lineNumbers: boolean;
   wrapText: boolean;
+  autoIndent: boolean;
   vimMode: boolean;
 }
 
@@ -126,12 +137,13 @@ export const Editor = ({ document, settings, ref, ...props }: EditorProps) => {
     return null;
   }
 
-  const { theme, fontFamily, lineNumbers, wrapText, vimMode } = {
+  const { theme, fontFamily, lineNumbers, wrapText, vimMode, autoIndent } = {
     theme: "dracula",
     fontFamily: "IBM Plex Mono",
     lineNumbers: false,
     wrapText: false,
     vimMode: false,
+    autoIndent: false,
     ...settings,
   };
 
@@ -181,6 +193,7 @@ export const Editor = ({ document, settings, ref, ...props }: EditorProps) => {
     lineNumbers ? lineNumbersExtension() : [],
     vimMode ? vim() : [],
     wrapText ? EditorView.lineWrapping : [],
+    autoIndent ? [] : noAutoIndent(),
   ];
 
   // If it's read-only, put a div in front of the editor so that the user

--- a/packages/web/src/components/session-command-dialog.tsx
+++ b/packages/web/src/components/session-command-dialog.tsx
@@ -30,7 +30,6 @@ import {
   Settings,
   Share,
   Monitor,
-  IndentIcon
 } from "lucide-react";
 import { Link } from "react-router-dom";
 import { useState } from "react";
@@ -57,7 +56,7 @@ export default function SessionCommandDialog({
   onEditorSettingsChange,
   ...props
 }: SessionCommandDialogProps) {
-  const { fontFamily, theme, vimMode, lineNumbers, wrapText, autoIndent } = editorSettings;
+  const { fontFamily, theme, vimMode, lineNumbers, wrapText } = editorSettings;
 
   const [pages, setPages] = useState<string[]>([]);
 
@@ -187,17 +186,6 @@ export default function SessionCommandDialog({
                 >
                   <WrapText className="mr-2 h-4 w-4" />
                   <span>{wrapText ? "Disable" : "Enable"} Word Wrapping</span>
-                </CommandItem>
-                <CommandItem
-                  onSelect={wrapHandler(() => 
-                    onEditorSettingsChange({
-                      ...editorSettings,
-                      autoIndent: !autoIndent,
-                    }),
-                  )}
-                >
-                  <IndentIcon className="mr-2 h-4 w-4" />
-                  <span>{autoIndent ? "Disable" : "Enable"} Auto Indent New Line</span>
                 </CommandItem>
                 <CommandItem
                   onSelect={wrapHandler(() =>

--- a/packages/web/src/components/session-command-dialog.tsx
+++ b/packages/web/src/components/session-command-dialog.tsx
@@ -30,6 +30,7 @@ import {
   Settings,
   Share,
   Monitor,
+  IndentIcon
 } from "lucide-react";
 import { Link } from "react-router-dom";
 import { useState } from "react";
@@ -56,7 +57,7 @@ export default function SessionCommandDialog({
   onEditorSettingsChange,
   ...props
 }: SessionCommandDialogProps) {
-  const { fontFamily, theme, vimMode, lineNumbers, wrapText } = editorSettings;
+  const { fontFamily, theme, vimMode, lineNumbers, wrapText, autoIndent } = editorSettings;
 
   const [pages, setPages] = useState<string[]>([]);
 
@@ -186,6 +187,17 @@ export default function SessionCommandDialog({
                 >
                   <WrapText className="mr-2 h-4 w-4" />
                   <span>{wrapText ? "Disable" : "Enable"} Word Wrapping</span>
+                </CommandItem>
+                <CommandItem
+                  onSelect={wrapHandler(() => 
+                    onEditorSettingsChange({
+                      ...editorSettings,
+                      autoIndent: !autoIndent,
+                    }),
+                  )}
+                >
+                  <IndentIcon className="mr-2 h-4 w-4" />
+                  <span>{autoIndent ? "Disable" : "Enable"} Auto Indent New Line</span>
                 </CommandItem>
                 <CommandItem
                   onSelect={wrapHandler(() =>

--- a/packages/web/src/settings.json
+++ b/packages/web/src/settings.json
@@ -45,6 +45,7 @@
     "sardine": "panic()",
     "dummy": "silence"
   },
+  "noAutoIndent": [ "mercury", "mercury-web" ],
   "webTargets": ["hydra", "mercury-web", "punctual", "strudel"],
   "repoUrl": "https://github.com/munshkr/flok",
   "changeLogUrl": "https://github.com/munshkr/flok/blob/main/CHANGELOG.md#changelog"

--- a/packages/web/src/settings.json
+++ b/packages/web/src/settings.json
@@ -45,7 +45,7 @@
     "sardine": "panic()",
     "dummy": "silence"
   },
-  "noAutoIndent": [ "mercury", "mercury-web" ],
+  "noAutoIndent": ["mercury", "mercury-web"],
   "webTargets": ["hydra", "mercury-web", "punctual", "strudel"],
   "repoUrl": "https://github.com/munshkr/flok",
   "changeLogUrl": "https://github.com/munshkr/flok/blob/main/CHANGELOG.md#changelog"


### PR DESCRIPTION
Since there is no grammar/language in codemirror for Mercury I've been using Javascript as default. The highlighting works quite well, but it gets confused with the auto-indentations, sometimes leading to a lot of tabs when you enter. This PR removes the auto-indentation feature when mercury or mercury-web is selected as target. 

At first I added this feature to the settings. But I think it makes more sense to have this setting dynamically change if the target is selected to be Mercury. Because otherwise the auto-indentation doesn't work when having multiple panes like Hydra and Mercury next to eachother.