### PR TITLE
adding `cmd/ctrl-alt-h` to hide editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,21 @@ Web-based P2P collaborative editor for live coding music and graphics
 
 *Some keybindings may differ depending on the language/target you choose, and the operating system*
 
-| Keybinding                | Function                             |
-| ------------------------- | ------------------------------------ |
-| `alt/option` `enter`      | Evaluate all                         |
-| `ctrl/cmd` `enter`        | Evaluate block, Evaluate selection   |
-| `shift` `enter`           | Evaluate line                        |
-| `ctrl/cmd/option/alt` `.` | Silence (output depends on language) |
-| `cmd/ctrl` `shift` `h`    | Show/Hide editor panels              |
-| `cmd/ctrl` `x`            | Cut selected text                    |
-| `cmd/ctrl` `c`            | Copy selected text                   |
-| `cmd/ctrl` `v`            | Paste cut/copied text                |
-| `cmd/ctrl` `z/u`          | Undo edit                            |
-| `cmd/ctrl` `shift` `z/u`  | Redo edit                            |
-| `cmd/ctrl` `}`            | add indentation                      |
-| `cmd/ctrl` `{`            | remove indentation                   |
-| `cmd/ctrl` `f`            | search and replace                   |
+| Keybinding                 | Function                             |
+| -------------------------- | ------------------------------------ |
+| `alt/option` `enter`       | Evaluate all                         |
+| `ctrl/cmd` `enter`         | Evaluate block, Evaluate selection   |
+| `shift` `enter`            | Evaluate line                        |
+| `ctrl/cmd/option/alt` `.`  | Silence (output depends on language) |
+| `cmd/ctrl` `shift/alt` `h` | Show/Hide editor panels              |
+| `cmd/ctrl` `x`             | Cut selected text                    |
+| `cmd/ctrl` `c`             | Copy selected text                   |
+| `cmd/ctrl` `v`             | Paste cut/copied text                |
+| `cmd/ctrl` `z/u`           | Undo edit                            |
+| `cmd/ctrl` `shift` `z/u`   | Redo edit                            |
+| `cmd/ctrl` `}`             | add indentation                      |
+| `cmd/ctrl` `{`             | remove indentation                   |
+| `cmd/ctrl` `f`             | search and replace                   |
 
 *On Mac:*
 

--- a/packages/web/src/routes/session.tsx
+++ b/packages/web/src/routes/session.tsx
@@ -474,7 +474,7 @@ export function Component() {
     },
     [documents, ...editorRefs],
   );
-  useShortcut(["Meta-Shift-H", "Control-Shift-H"], () => {
+  useShortcut(["Meta-Shift-H", "Control-Shift-H", "Meta-Alt-H","Control-Alt-H"], () => {
     setHidden((p) => !p);
   });
   useShortcut(["Control-,", "Meta-,"], () => {

--- a/packages/web/src/routes/session.tsx
+++ b/packages/web/src/routes/session.tsx
@@ -474,9 +474,12 @@ export function Component() {
     },
     [documents, ...editorRefs],
   );
-  useShortcut(["Meta-Shift-H", "Control-Shift-H", "Meta-Alt-H","Control-Alt-H"], () => {
-    setHidden((p) => !p);
-  });
+  useShortcut(
+    ["Meta-Shift-H", "Control-Shift-H", "Meta-Alt-H", "Control-Alt-H"],
+    () => {
+      setHidden((p) => !p);
+    },
+  );
   useShortcut(["Control-,", "Meta-,"], () => {
     setMessagesPanelExpanded((v) => !v);
   });


### PR DESCRIPTION
`ctrl-shift-h` does not work as it is a firefox shortcut, adding `ctrl-alt-h` as an alternative