### PR TITLE
Shift-Enter not a valid eval keymap in Mercury

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7728,7 +7728,8 @@
       "version": "1.5.25",
       "resolved": "https://registry.npmjs.org/asciichart/-/asciichart-1.5.25.tgz",
       "integrity": "sha512-PNxzXIPPOtWq8T7bgzBtk9cI2lgS4SJZthUHEiQ1aoIc3lNzGfUvIvo9LiAnq26TACo9t1/4qP6KTGAUbzX9Xg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/asn1.js": {
       "version": "5.4.1",
@@ -7897,6 +7898,7 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
       "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -9703,7 +9705,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
       "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/djipevents": {
       "version": "2.0.7",
@@ -13387,25 +13390,27 @@
       }
     },
     "node_modules/mercury-engine": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/mercury-engine/-/mercury-engine-1.2.2.tgz",
-      "integrity": "sha512-N2qC2sqc/quCRiSSjO9Z5WDj9EpEFBA3qHJh8MnRQxveE4SUrihMtWMIEaCn01hi0aMsXQDrb+N5reiAcj704A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mercury-engine/-/mercury-engine-1.3.0.tgz",
+      "integrity": "sha512-ydThvYE/x2WvdmXafrJxF3MefUuvMDnsxAIP4Q0OMl/wLzLd24eoArifLOcb/MYGnNwilb5zVvidXIz7GGlfdQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "mercury-lang": "^1.9.x",
+        "mercury-lang": "^1.9.10",
         "tone": "^14.7.77",
         "webmidi": "^3.1.6"
       }
     },
     "node_modules/mercury-lang": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/mercury-lang/-/mercury-lang-1.9.6.tgz",
-      "integrity": "sha512-FBmTYy3vourq2VcmhgM/1tJRVjzZ/GYLEUe3QQ9dqsNlK54RiTTYcDkqGRLry0GnF7bfWJi9GUWvqCcQvY4VZg==",
+      "version": "1.9.10",
+      "resolved": "https://registry.npmjs.org/mercury-lang/-/mercury-lang-1.9.10.tgz",
+      "integrity": "sha512-crvqAJTTx9qq5bnXIRgqd4uj5ngi5PeiBHjXvtcCTe9HWGYaYnmbCDjWInpwjor0BygyYD7kIR0RTW5GjxjunA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "moo": "^0.5.1",
         "nearley": "^2.20.1",
-        "total-serialism": "^2.7.1"
+        "total-serialism": "^2.7.5"
       }
     },
     "node_modules/merge-descriptors": {
@@ -13952,7 +13957,8 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
       "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -14043,6 +14049,7 @@
       "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
       "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "commander": "^2.19.0",
         "moo": "^0.5.0",
@@ -14064,7 +14071,8 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -16274,13 +16282,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
       "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-      "dev": true
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/randexp": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
       "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "discontinuous-range": "1.0.0",
         "ret": "~0.1.10"
@@ -16977,6 +16987,7 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12"
       }
@@ -17223,7 +17234,8 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
       "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.3.8",
@@ -18350,10 +18362,11 @@
       }
     },
     "node_modules/total-serialism": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/total-serialism/-/total-serialism-2.7.2.tgz",
-      "integrity": "sha512-JNYRABk4uImmU6KVcoQyFEn9r1Hv28bP8SNX7N++vi3u779R6TQhod+Ax4nBNJeBpTRBnH5yBGuMD3pmyS2IoA==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/total-serialism/-/total-serialism-2.7.5.tgz",
+      "integrity": "sha512-KZ5/EHo4MZGc9L9EgQmXziDX4/3taAmIOgVvSZVAimJ7rjruNglndOp8Ediq1ZdzfPeX+3Qwmw7uW+hArAtFGA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tonaljs/tonal": "^3.7.5",
         "asciichart": "^1.5.25",
@@ -18366,6 +18379,7 @@
       "resolved": "https://registry.npmjs.org/@tonaljs/abc-notation/-/abc-notation-3.5.5.tgz",
       "integrity": "sha512-VwYS/u2MJl6hYWF3N7G+QFp0plqjsu0170jcuy+1Gk1lsk6kOrn7Zb845M5YYv9JzjPOjA4Qm0fRXYcMKadayQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tonaljs/core": "^3.5.4"
       }
@@ -18375,6 +18389,7 @@
       "resolved": "https://registry.npmjs.org/@tonaljs/array/-/array-3.2.9.tgz",
       "integrity": "sha512-eJTCGsHDy/9IHMN1qHdceaWTLH2okPXRlAlpycqPd0rCP5G7XL8hWO4eu9ck/oNFTw2CNGEbJQtl0iEpnm/oYw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tonaljs/core": "^3.5.4"
       }
@@ -18384,6 +18399,7 @@
       "resolved": "https://registry.npmjs.org/@tonaljs/chord/-/chord-3.9.0.tgz",
       "integrity": "sha512-0c1MKOl+qazh/kpx/qt8I+r0HlYzQBtQ1t/rnuP+R6nYX/BeLBY0ZC7ZbB79Eu7LpnnbchKuPOezZsmOgrjU3Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tonaljs/chord-detect": "^3.7.0",
         "@tonaljs/chord-type": "^3.7.0",
@@ -18398,6 +18414,7 @@
       "resolved": "https://registry.npmjs.org/@tonaljs/chord-detect/-/chord-detect-3.7.0.tgz",
       "integrity": "sha512-1z8DG8avmtFXS8/vnfzJEgOP+zZvd827g4qjQKa1NyjLmrOp3BWi77iBhs4ktctxIT3xYPIGF8aH+DH5L73Tbw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tonaljs/chord-type": "^3.7.0",
         "@tonaljs/core": "^3.5.4",
@@ -18409,6 +18426,7 @@
       "resolved": "https://registry.npmjs.org/@tonaljs/chord-type/-/chord-type-3.7.0.tgz",
       "integrity": "sha512-Rg3xTRFtJOnHV0UILjFhYKn4+7JsOkAMMxQEEXcxSBTqrC6LQ4QSuOjkxpd1Q7tGqTkAdQCyNQJsR/iF4fXYsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tonaljs/core": "^3.5.4",
         "@tonaljs/pcset": "^3.5.4"
@@ -18418,25 +18436,29 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/@tonaljs/collection/-/collection-3.5.3.tgz",
       "integrity": "sha512-RzEsHhbaZCAREWy0XuNRkHO//RgpoTw3FeWA7aeCyuVr2B36neLDnihBmo9T6KZBO/hSLcmPQy/NOEcvhsaVuA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/total-serialism/node_modules/@tonaljs/core": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/@tonaljs/core/-/core-3.5.4.tgz",
       "integrity": "sha512-Rhe7TKNmkOb9/Ilu1ByCI7jIEc0hztGbfHMtI7N5sIdAXVaVzz0WaZdEuPKnAYibS8IRsT5Jm3B/oAEy5CdQAQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/total-serialism/node_modules/@tonaljs/duration-value": {
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/@tonaljs/duration-value/-/duration-value-3.6.3.tgz",
       "integrity": "sha512-y+jFjfb5Knu9QR+w8n3YnWqTaJmeDJr5SYLZZiG/BMvIr7BX40hma/F7IdQ6fi6e0gD+cm0VNCTlTDXVnUmdww==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/total-serialism/node_modules/@tonaljs/interval": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/@tonaljs/interval/-/interval-3.5.4.tgz",
       "integrity": "sha512-cgbTL3SNpzRMXkFh93y3Qy4IXmZOGF12we1E6u4swzR1H1D3OsQrEugPoYzOhiIax3Q+mZ9vm9mgk/KWzCIhww==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tonaljs/core": "^3.5.4"
       }
@@ -18446,6 +18468,7 @@
       "resolved": "https://registry.npmjs.org/@tonaljs/key/-/key-3.5.5.tgz",
       "integrity": "sha512-3WRrPin/kMlaAsx0/PhJqKAMwO97PZmlN8399S5/B1Peh9BUin1ChteyjfLwsfcjkhfWh35jB+Pp8XG8iQRc6A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tonaljs/core": "^3.5.3",
         "@tonaljs/note": "^3.5.3",
@@ -18457,6 +18480,7 @@
       "resolved": "https://registry.npmjs.org/@tonaljs/midi/-/midi-3.5.4.tgz",
       "integrity": "sha512-Xtunz9cVWTI5hJ9OjGXYWwlbJwcrof/IsmshvYmZXQGOhtVY2PPhY3JSKfAVN+CLFOraEjVJ4/YEGoFutF+yJA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tonaljs/core": "^3.5.4"
       }
@@ -18466,6 +18490,7 @@
       "resolved": "https://registry.npmjs.org/@tonaljs/mode/-/mode-3.5.4.tgz",
       "integrity": "sha512-iu3aFh62UPeNNrgGNLm/lvURx2L83E2+u78ESDjO86kYgSbkFKuK7D8MHynFSwFUmQCfw4+aOq9gHByuv5lz5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tonaljs/core": "^3.5.4",
         "@tonaljs/pcset": "^3.5.4"
@@ -18476,6 +18501,7 @@
       "resolved": "https://registry.npmjs.org/@tonaljs/note/-/note-3.6.0.tgz",
       "integrity": "sha512-riwAjPdQBa01uhCl0h+3vc0M3VW/NS982pg3k2ntKYiC8YsSRu0tR7yDtUbOWwMjaj8loAk68Snmm44mutiIdQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tonaljs/core": "^3.5.4",
         "@tonaljs/midi": "^3.5.4"
@@ -18486,6 +18512,7 @@
       "resolved": "https://registry.npmjs.org/@tonaljs/pcset/-/pcset-3.5.4.tgz",
       "integrity": "sha512-RaB1KJoq5ZhXuDEWPlf1NWi1Cwa67yUr43usDhw/abvvIyZAkEJ1jyg4Yiks29ua7zBeQSyrEU+leuKxFBTGcQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tonaljs/collection": "^3.5.3",
         "@tonaljs/core": "^3.5.4"
@@ -18496,6 +18523,7 @@
       "resolved": "https://registry.npmjs.org/@tonaljs/progression/-/progression-3.7.0.tgz",
       "integrity": "sha512-AkqVg5H9Jos8GquBav4WkxxlnSg8PEjKobFUyfEeU3BHfFo1QNOnBmXN8JhSxR1+tY7KDCEK574LYP8xpqThAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tonaljs/chord": "^3.9.0",
         "@tonaljs/core": "^3.5.4",
@@ -18507,6 +18535,7 @@
       "resolved": "https://registry.npmjs.org/@tonaljs/range/-/range-3.6.0.tgz",
       "integrity": "sha512-KXcOGrxmHno7hHbHkg0UPM3NnDf0o7hjED6EAZUkBmtHrfqEWtKVEpwDcFgilGSJ1BfNj1Odp77pLtqjXcOQVQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tonaljs/collection": "^3.5.3",
         "@tonaljs/midi": "^3.5.4"
@@ -18517,6 +18546,7 @@
       "resolved": "https://registry.npmjs.org/@tonaljs/roman-numeral/-/roman-numeral-3.5.4.tgz",
       "integrity": "sha512-jwN8lTZb0nernJZ45piKsh0E8GeA4Xiq2XR03NpL7oS9KMHyZkHx4Otripiqvfns0aVgvDP4Da6c7FEhPY8zJA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tonaljs/core": "^3.5.4"
       }
@@ -18526,6 +18556,7 @@
       "resolved": "https://registry.npmjs.org/@tonaljs/scale/-/scale-3.7.0.tgz",
       "integrity": "sha512-L9Lw9ZBttjbo06br14XfIseJ/QDCLynvfmWoj/E00QKDC6cNJbDhpUxce3Xat/CD7CGuhVU8ql9PsT8bG+/wtg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tonaljs/chord-type": "^3.7.0",
         "@tonaljs/collection": "^3.5.3",
@@ -18540,6 +18571,7 @@
       "resolved": "https://registry.npmjs.org/@tonaljs/scale-type/-/scale-type-3.6.0.tgz",
       "integrity": "sha512-AN5C33Q1l3pgkBxLZ9gQIz98aG8dQ6iJx/FNvIqdzAR0BPtkIJk8z2lrKeDkSSKPPkykUuycroloJaRp5FuOpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tonaljs/core": "^3.5.4",
         "@tonaljs/pcset": "^3.5.4"
@@ -18549,13 +18581,15 @@
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/@tonaljs/time-signature/-/time-signature-3.6.3.tgz",
       "integrity": "sha512-M1WNX6btgY53NDV6/aNZl6wAzRbjam3P2edSf1+ptZ0PZEayf/eCx8A0A2oXHFpOT+p/D2SV2EWGrTGtlu1E+Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/total-serialism/node_modules/@tonaljs/tonal": {
       "version": "3.7.5",
       "resolved": "https://registry.npmjs.org/@tonaljs/tonal/-/tonal-3.7.5.tgz",
       "integrity": "sha512-k5TAIj4F+q6I9yTAFY46YkBpUMtuEZLsCAiD0HJl7f5yV7qzZj5/rz/SwQMrgKcBoNNXw+kVw+SVTr9sgb/RBw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tonaljs/abc-notation": "^3.5.4",
         "@tonaljs/array": "^3.2.8",
@@ -20165,7 +20199,7 @@
         "eslint-plugin-react-refresh": "^0.4.5",
         "hydra-synth": "^1.3.29",
         "lucide-react": "^0.128.0",
-        "mercury-engine": "^1.2.2",
+        "mercury-engine": "^1.3.0",
         "p5": "^1.9.0",
         "postcss": "^8.4.21",
         "prettier": "^3.4.2",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -87,7 +87,7 @@
     "eslint-plugin-react-refresh": "^0.4.5",
     "hydra-synth": "^1.3.29",
     "lucide-react": "^0.128.0",
-    "mercury-engine": "^1.2.2",
+    "mercury-engine": "^1.3.0",
     "p5": "^1.9.0",
     "postcss": "^8.4.21",
     "prettier": "^3.4.2",

--- a/packages/web/src/components/editor.tsx
+++ b/packages/web/src/components/editor.tsx
@@ -79,7 +79,7 @@ const extraKeymap = () => {
     { key: "Shift-Cmd-7", run: toggleLineComment },
     { key: "Shift-Alt-7", run: toggleLineComment },
     { key: "Alt-/", run: toggleLineComment },
-    { key: "Ctrl-/", run: toggleLineComment },
+    { key: "Ctrl-/", run: toggleLineComment }
   ]);
 };
 
@@ -107,11 +107,12 @@ const flokSetup = (
     ? "document"
     : "block";
   const web = webTargets.includes(doc.target);
+  const noLineEval = doc.target === 'mercury' || doc.target === 'mercury-web';
 
   return [
     flashField(),
     remoteEvalFlash(doc),
-    Prec.high(evalKeymap(doc, { defaultMode, web })),
+    Prec.high(evalKeymap(doc, { defaultMode, web, lineEvalKeys: noLineEval ? [] : ['Shift-Enter'] })),
     panicKeymap(doc),
     extraKeymap(),
     autoIndentKeymap(doc),


### PR DESCRIPTION
Hey! 

I remember in the beginning when I added Mercury I made specific keymaps so that when someone evaluates in Mercury you can only evaluate the entire page. Now some things have been moved around it seems, and it is now again possible to use `shift-enter` to evaluate a single line. However, this is an issue for Mercury since if you click this keymap accidentally during a performance everything will be deleted except for that single line that is evaluated...

I've changed a bit so the the lineEvalKeys is set to `[]` when the target is `mercury` or `mercury-web`.