### PR TITLE
Hydra fft defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,10 +304,11 @@ fft(index: number,
 
 Parameters:
 
-- `index: number` : The index of the bucket to return the value from.
-- `buckets: number`: The number of buckets to combine the underlying FFT data
+- `index: number` (default: 0): The index of the bucket to return the value from.
+- `buckets: number` (default:1): The number of buckets to combine the underlying FFT data
   too. Defaults to 8.
-- `options?: { min?: number; max?: number, scale?: number }`:
+- `options?: { min?: number; max?: number, scale?: number } | string`:
+  - if string, it sets the `analyzerId` option directly
   - `min?: number`: Minimum clamp value of the underlying data. Defaults to
     -150.
   - `max?: number`: Maximum clamp value of the underlying data. Defaults to 0.

--- a/packages/web/src/lib/hydra-wrapper.ts
+++ b/packages/web/src/lib/hydra-wrapper.ts
@@ -109,16 +109,46 @@ export class HydraWrapper {
     // Enables Hydra to use Strudel frequency data
     // with `.scrollX(() => fft(1,0)` it will influence the x-axis, according to the fft data
     // first number is the index of the bucket, second is the number of buckets to aggregate the number too
-    window.fft = (
-      index: number,
-      buckets: number = 8,
+    window.fft = fftImpl;
+
+    const self = this;
+
+    function fftImpl(
+      index?: number,
+      buckets?: number,
+      options?: string,
+    ): number;
+    function fftImpl(
+      index?: number,
+      buckets?: number,
       options?: {
         min?: number;
         max?: number;
         scale?: number;
         analyzerId?: string;
       },
-    ) => {
+    ): number;
+    function fftImpl(
+      index?: number,
+      buckets?: number,
+      options?:
+        | {
+            min?: number;
+            max?: number;
+            scale?: number;
+            analyzerId?: string;
+          }
+        | string,
+    ): number {
+      index = index ?? 0;
+      buckets = buckets ?? 1;
+      options =
+        options != null
+          ? typeof options === "string"
+            ? { analyzerId: options }
+            : options
+          : options;
+
       const analyzerId = options?.analyzerId ?? "flok-master";
       const min = options?.min ?? -150;
       const scale = options?.scale ?? 1;
@@ -128,7 +158,7 @@ export class HydraWrapper {
       if (window.strudel == undefined) return 0.5;
 
       // If display settings are not enabled, we just return a default value
-      if (!(this._displaySettings.enableFft ?? true)) return 0.5;
+      if (!(self._displaySettings.enableFft ?? true)) return 0.5;
 
       // Enable auto-analyze
       window.strudel.enableAutoAnalyze = true;
@@ -155,7 +185,7 @@ export class HydraWrapper {
           .slice(bucketSize * index, bucketSize * (index + 1))
           .reduce((a, b) => a + b, 0) / bucketSize
       );
-    };
+    }
 
     this.initialized = true;
     console.log("Hydra initialized");


### PR DESCRIPTION
While playing with the fft function over in [nudel](https://nudel.cc) for the last few month, I've noticed that the defaults currently (`fft(1,8)`) don't make much sense in most cases.

I almost always change them to `fft(0,1)`, so I think these are better values.

Sadly this change is technically compatability breaking with current flok-rooms.
I think that is fine as the impact is small-ish.

In general 0,1 has a bit bigger amplitudes, but it also incorporates all of the frequency spectrum (and not only an eights).


Changes:
- change defaults of fft function:
    -  `index` is now 0
    -  `buckets` is now 1
- the third parameters can now also just be a string, setting the analyzer id directly.
    -  this is the most used other option, and it was noisy to set it with the object each time 
