### PR TITLE
Patch Hydra source initScreen to only call the screen dialog once

### DIFF
--- a/packages/web/src/lib/hydra-wrapper.ts
+++ b/packages/web/src/lib/hydra-wrapper.ts
@@ -187,6 +187,26 @@ export class HydraWrapper {
       );
     }
 
+    /**
+     * Patching HydraSources
+     */
+    const HydraSource = this._hydra.s?.[0].constructor;
+
+    // Patching initScreen
+    // to only init screen once
+    let screenOptions = "non-init";
+    const originScreen = HydraSource.prototype.initScreen;
+    let screenIsInit = false;
+    HydraSource.prototype.initScreen = function (options: any) {
+      if (screenOptions !== options) {
+        originScreen.bind(this)(options);
+      } else if (!screenIsInit) {
+        originScreen.bind(this)(options);
+      }
+      screenIsInit = true;
+      screenOptions = options;
+    };
+
     this.initialized = true;
     console.log("Hydra initialized");
   }

--- a/packages/web/src/lib/hydra-wrapper.ts
+++ b/packages/web/src/lib/hydra-wrapper.ts
@@ -194,17 +194,13 @@ export class HydraWrapper {
 
     // Patching initScreen
     // to only init screen once
-    let screenOptions = "non-init";
     const originScreen = HydraSource.prototype.initScreen;
     let screenIsInit = false;
-    HydraSource.prototype.initScreen = function (options: any) {
-      if (screenOptions !== options) {
-        originScreen.bind(this)(options);
-      } else if (!screenIsInit) {
-        originScreen.bind(this)(options);
+    HydraSource.prototype.initScreen = function () {
+      if (!screenIsInit) {
+        originScreen.bind(this)();
       }
       screenIsInit = true;
-      screenOptions = options;
     };
 
     this.initialized = true;


### PR DESCRIPTION
`initScreen` can be quit disruptive when performing.

especially with multiple people evaluating the code it can lead to multiple share dialogs popping up, even when disabled by commenting it out asap.

This will only call the hydra init function once. 


Patching Hydra is a new step for flok, ideally Hydra would handle this in all cases, but its an easy enough fix here that it fits.

(https://nudel.cc just got this feature too)